### PR TITLE
OTC-242: Automatically update version in About in Mobile Apps

### DIFF
--- a/claimManagement/build.gradle
+++ b/claimManagement/build.gradle
@@ -1,4 +1,13 @@
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
 apply plugin: 'com.android.application'
+
+static def getDate() {
+    LocalDateTime date = LocalDateTime.now()
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern('dd MMMM yyyy HH:mm').withLocale(Locale.UK)
+    return date.format(formatter)
+}
 
 android {
     compileSdkVersion 28
@@ -24,40 +33,41 @@ android {
     flavorDimensions 'std'
 
     productFlavors.all {
-        resValue "string", "app_name", "openIMIS Claims"
+        resValue "string", "app_name_claims", "openIMIS Claims"
+        resValue "string", "ReleaseDateValue", getDate()
     }
 
     productFlavors {
         demoProd {
             applicationIdSuffix ".demoProd"
-            resValue "string", "app_name", "Claims Demo"
+            resValue "string", "app_name_claims", "Claims Demo"
             dimension 'std'
         }
 
         demoRelease {
             applicationIdSuffix ".demoRelease"
-            resValue "string", "app_name", "Claims Release"
+            resValue "string", "app_name_claims", "Claims Release"
             dimension 'std'
         }
 
         chfDev {
             applicationIdSuffix ".chfDev"
-            resValue "string", "app_name", "Claims CHF"
+            resValue "string", "app_name_claims", "Claims CHF"
             dimension 'std'
         }
         mvDev {
             applicationIdSuffix ".mvDev"
-            resValue "string", "app_name", "Claims MV"
+            resValue "string", "app_name_claims", "Claims MV"
             dimension 'std'
         }
         bephaDev {
             applicationIdSuffix ".bephaDev"
-            resValue "string", "app_name", "Claims BEPHA"
+            resValue "string", "app_name_claims", "Claims BEPHA"
             dimension 'std'
         }
         local {
             applicationIdSuffix ".local"
-            resValue "string", "app_name", "Claims Local"
+            resValue "string", "app_name_claims", "Claims Local"
             dimension 'std'
         }
     }

--- a/claimManagement/src/main/AndroidManifest.xml
+++ b/claimManagement/src/main/AndroidManifest.xml
@@ -19,15 +19,15 @@
         android:name="org.openimis.imisclaims.Global"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher_round"
-        android:label="@string/app_name"
+        android:label="@string/app_name_claims"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        tools:replace="android:icon">
+        tools:replace="android:icon,android:label">
         <uses-library android:name="org.apache.http.legacy" android:required="false"/>
         <activity
             android:name="org.openimis.imisclaims.MainActivity"
-            android:label="@string/app_name"
+            android:label="@string/app_name_claims"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -68,11 +68,12 @@
         <activity
             android:name="org.openimis.imisclaims.Report"
             android:label="@string/title_activity_report"
-            android:theme="@style/AppTheme.NoActionBar"></activity>
+            android:theme="@style/AppTheme.NoActionBar" />
         <uses-library
             android:name="org.apache.http.legacy"
             android:required="false"/>
-        <activity android:name=".SearchClaims"></activity>
+
+        <activity android:name=".SearchClaims" />
         <activity android:name=".Claims">
 
         </activity>

--- a/claimManagement/src/main/java/org/openimis/imisclaims/About.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/About.java
@@ -15,8 +15,10 @@ public class About extends AppCompatActivity {
         setContentView(R.layout.activity_about);
 
         final ActionBar actionBar = getSupportActionBar();
-        actionBar.setDisplayHomeAsUpEnabled(true);
-        actionBar.setTitle("");
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setTitle("");
+        }
     }
 
     public boolean onOptionsItemSelected(MenuItem item){

--- a/claimManagement/src/main/res/layout/activity_about.xml
+++ b/claimManagement/src/main/res/layout/activity_about.xml
@@ -1,38 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@drawable/side_nav_bar"
     android:orientation="vertical"
     android:padding="25dp"
-    android:background="@drawable/side_nav_bar"
     tools:context="org.openimis.imisclaims.About">
-
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:typeface="monospace"
+        android:layout_marginStart="10sp"
         android:fontFamily="sans-serif-light"
-        android:textSize="25dp"
+        android:text="@string/about"
         android:textColor="@color/white"
-        android:layout_marginLeft="10dp"
-        android:text="@string/about" />
+        android:textSize="25sp"
+        android:typeface="monospace" />
     <ImageView
         android:layout_width="80dp"
         android:layout_height="80dp"
-        android:src="@mipmap/ic_launcher_round"/>
-    
-    <TextView
+        android:src="@mipmap/ic_launcher_round" />
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:typeface="monospace"
-        android:fontFamily="sans-serif-light"
-        android:textSize="15dp"
-        android:layout_marginLeft="10dp"
-        android:textColor="@color/white"
-        android:text="@string/release"
-        />
-
+        android:layout_height="25sp"
+        android:orientation="horizontal">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginStart="10dp"
+            android:fontFamily="sans-serif-light"
+            android:text="@string/Version"
+            android:textColor="@color/white"
+            android:textSize="18sp"
+            android:typeface="monospace" />
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginStart="10dp"
+            android:fontFamily="sans-serif-light"
+            android:text="2.0.1"
+            android:textColor="@color/white"
+            android:textSize="18sp"
+            android:typeface="monospace" />
+    </LinearLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="25sp"
+        android:layout_marginTop="5sp"
+        android:orientation="horizontal">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:fontFamily="sans-serif-light"
+            android:text="@string/ReleaseDate"
+            android:textColor="@color/white"
+            android:textSize="18sp"
+            android:typeface="monospace" />
+        <View
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginStart="10dp"
+            android:fontFamily="sans-serif-light"
+            android:text="@string/ReleaseDateValue"
+            android:textColor="@color/white"
+            android:textSize="18sp"
+            android:typeface="monospace" />
+    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Changes:
- Changed app_name resource key to app_name_claims to avoid conflicts
- Added generated build datetime resource to be used in About page
- Modified About layout to fit separate version and release date entries

[https://openimis.atlassian.net/browse/OTC-242](https://openimis.atlassian.net/browse/OTC-242)