### PR TITLE
OTC-254: Andoid 10/11 compatibility for claim app

### DIFF
--- a/General/build.gradle
+++ b/General/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 7
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 30
+    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion 7
-        targetSdkVersion 7
+        targetSdkVersion 30
     }
 
     buildTypes {

--- a/General/src/main/AndroidManifest.xml
+++ b/General/src/main/AndroidManifest.xml
@@ -4,8 +4,6 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
-    <uses-sdk android:minSdkVersion="7" />
-
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application
         android:label="@string/app_name" >

--- a/General/src/main/java/org/openimis/general/General.java
+++ b/General/src/main/java/org/openimis/general/General.java
@@ -4,13 +4,6 @@ package org.openimis.general;
 import java.io.IOException;
 import java.util.Locale;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.util.EntityUtils;
-
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;

--- a/claimManagement/src/main/AndroidManifest.xml
+++ b/claimManagement/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:requestLegacyExternalStorage="true"
         tools:replace="android:icon,android:label">
         <uses-library android:name="org.apache.http.legacy" android:required="false"/>
         <activity

--- a/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
@@ -129,7 +129,7 @@ public class MainActivity extends AppCompatActivity
         drawer.addDrawerListener(toggle);
         toggle.syncState();
 
-
+        createFolders();
 
         NavigationView navigationView = (NavigationView) findViewById(R.id.nav_view);
         navigationView.setNavigationItemSelectedListener(this);
@@ -500,11 +500,14 @@ public class MainActivity extends AppCompatActivity
         sql.onOpen(db);*/
     }
 
-    public void CreateFolders(){
-        //Here we are creating a directory
-        File MyDir = new File(global.getMainDirectory());
-        MyDir.mkdir();
+    public void createFolders() {
+        global.getMainDirectory();
+        String[] subdirectories = {"Enrolment", "Photos", "Database", "Authentications", "AcceptedClaims", "RejectedClaims", "Trash"};
+        for (String dir : subdirectories) {
+            global.getSubdirectory(dir);
+        }
     }
+
     private void isSDCardAvailable(){
 
         if (_General.isSDCardAvailable() == 0){

--- a/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
@@ -72,11 +72,11 @@ public class MainActivity extends AppCompatActivity
 
     TextView AdminName;
 
-    static String Path = global.getMainDirectory();
-    String AcceptedFolder = global.getSubdirectory("AcceptedClaims");
-    String RejectedFolder = global.getSubdirectory("RejectedClaims");
-    String PendingFolder = global.getMainDirectory();
-    String TrashFolder = global.getSubdirectory("Trash");
+    static String Path;
+    String AcceptedFolder;
+    String RejectedFolder;
+    String PendingFolder;
+    String TrashFolder;
 
     final String VersionField = "AppVersionEnquire";
     NotificationManager mNotificationManager;
@@ -104,9 +104,16 @@ public class MainActivity extends AppCompatActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        requestPermision();
+
+        Path = global.getMainDirectory();
+        AcceptedFolder = global.getSubdirectory("AcceptedClaims");
+        RejectedFolder = global.getSubdirectory("RejectedClaims");
+        PendingFolder = global.getMainDirectory();
+        TrashFolder = global.getSubdirectory("Trash");
+
         setContentView(R.layout.activity_main);
 
-        requestPermision();
         toRestApi = new ToRestApi();
         tokenl = new Token();
 

--- a/claimManagement/src/main/java/org/openimis/imisclaims/Synchronize.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/Synchronize.java
@@ -554,11 +554,9 @@ public class Synchronize extends AppCompatActivity {
     private void MoveFile(File file){
         switch(result){
             case 1:
-                //file.renameTo(new File(ClaimActivity.Path + "AcceptedClaims/" + file.getName()));
                 file.renameTo(new File(global.getSubdirectory("AcceptedClaims"), file.getName()));
                 break;
             case 2:
-                //file.renameTo(new File(ClaimActivity.Path + "RejectedClaims/" + file.getName()));
                 file.renameTo(new File(global.getSubdirectory("RejectedClaims"), file.getName()));
                 break;
         }


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OTC-254

Changes:
- removing some unnecessary import from General project
- thanks to above point I increased SDK version from 7 to 30 in General
- removed SDK min from general in Adnroid Manifest
- added createFolders method
- MainActivity - changes with processing file onCreate.