### PR TITLE
OTC-357: Move database to private storage

### DIFF
--- a/claimManagement/src/main/AndroidManifest.xml
+++ b/claimManagement/src/main/AndroidManifest.xml
@@ -33,7 +33,13 @@
         tools:replace="android:icon,android:label">
         <service
             android:name=".SynchronizeService"
-            android:exported="false" />
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="true"/>
+
+        <service
+            android:name=".MasterDataService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="true"/>
 
         <uses-library
             android:name="org.apache.http.legacy"

--- a/claimManagement/src/main/java/org/openimis/imisclaims/Global.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/Global.java
@@ -32,7 +32,6 @@ import android.content.res.Resources;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Environment;
-import android.support.v7.app.AppCompatActivity;
 import android.util.Base64;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -44,6 +43,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -68,7 +68,7 @@ public class Global extends Application {
     private static final String _DefaultRarPassword = RAR_PASSWORD;
     private Token JWTToken;
 
-    private final List<String> ProtectedDirectories = Arrays.asList("Authentications");
+    private final List<String> ProtectedDirectories = Arrays.asList("Authentications", "Databases");
 
 
     public Global() {
@@ -283,7 +283,7 @@ public class Global extends Application {
 
     private SecretKeySpec generateKey(String encPassword) throws Exception {
         final MessageDigest digest = MessageDigest.getInstance("SHA-256");
-        byte[] bytes = encPassword.getBytes("UTF-8");
+        byte[] bytes = encPassword.getBytes(StandardCharsets.UTF_8);
         digest.update(bytes, 0, bytes.length);
         byte[] key = digest.digest();
         return new SecretKeySpec(key, "AES");

--- a/claimManagement/src/main/java/org/openimis/imisclaims/ImisActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ImisActivity.java
@@ -172,18 +172,18 @@ public abstract class ImisActivity extends AppCompatActivity {
 
                                     if (isUserLogged) {
                                         runOnUiThread(() -> {
-                                            showToast(getResources().getString(R.string.Login_Successful));
+                                            showToast(R.string.Login_Successful);
                                             onLoggedIn.run();
                                         });
                                     } else {
                                         runOnUiThread(() -> {
-                                            showToast(getResources().getString(R.string.LoginFail));
+                                            showToast(R.string.LoginFail);
                                             showLoginDialogBox(onLoggedIn, onCancel);
                                         });
                                     }
                                 }).start();
                             } else {
-                                showToast(getResources().getString(R.string.Enter_Credentials));
+                                showToast(R.string.Enter_Credentials);
                                 dialog.dismiss();
                                 showLoginDialogBox(onLoggedIn, onCancel);
                             }
@@ -200,29 +200,67 @@ public abstract class ImisActivity extends AppCompatActivity {
 
     /**
      * Execute the task if internet is available and the user is logged in.
-     * If there is no network or the the user cancels login the task is canceled
+     * If there is no network or the the user cancels login the task is canceled.
      *
-     * @param task Task to do when the user is logged in
+     * @param task     Task to do when the user is logged in.
+     * @param onCancel Task to do when the initial task is canceled by rhe user or there is no internet.
      */
     protected void doLoggedIn(Runnable task, Runnable onCancel) {
-        if (global.isNetworkAvailable()) {
-            if (global.isLoggedIn()) {
-                task.run();
-            } else {
-                showLoginDialogBox(task, onCancel);
-            }
-        } else {
-            showToast(getResources().getString(R.string.InternetRequired));
-            onCancel.run();
-        }
+        doInOnlineMode(
+                () -> {
+                    if (global.isLoggedIn()) {
+                        task.run();
+                    } else {
+                        showLoginDialogBox(task, onCancel);
+                    }
+                },
+                () -> {
+                    showToast(R.string.InternetRequired);
+                    onCancel.run();
+                }
+        );
     }
 
+    /**
+     * Execute the task if internet is available and the user is logged in.
+     * If there is no network or the the user cancels login the task is canceled.
+     *
+     * @param task Task to do when the user is logged in.
+     */
     protected void doLoggedIn(Runnable task) {
         doLoggedIn(task, () -> {
         });
     }
 
+    /**
+     * Execute the task if internet is available
+     *
+     * @param task         Task to do in online mode
+     * @param onNoInternet Task to do, if there is no internet
+     */
+    protected void doInOnlineMode(Runnable task, Runnable onNoInternet) {
+        if (global.isNetworkAvailable()) {
+            task.run();
+        } else {
+            onNoInternet.run();
+        }
+    }
+
+    /**
+     * Execute the task if internet is available
+     *
+     * @param task Task to do in online mode
+     */
+    protected void doInOnlineMode(Runnable task) {
+        doInOnlineMode(task, () -> {
+        });
+    }
+
     protected void showToast(String message) {
         runOnUiThread(() -> Toast.makeText(this, message, Toast.LENGTH_LONG).show());
+    }
+
+    protected void showToast(int resourceId) {
+        showToast(getResources().getString(resourceId));
     }
 }

--- a/claimManagement/src/main/java/org/openimis/imisclaims/Login.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/Login.java
@@ -1,12 +1,8 @@
 package org.openimis.imisclaims;
 
-import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
-import org.apache.http.util.EntityUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.io.IOException;
 
 public class Login {
 

--- a/claimManagement/src/main/java/org/openimis/imisclaims/MapItems.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/MapItems.java
@@ -30,8 +30,6 @@ import android.widget.SimpleAdapter;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import org.openimis.imisclaims.R;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -378,8 +376,6 @@ public class MapItems extends AppCompatActivity {
 			}
 		}
 	}
-
-
-	}
+}
 
 

--- a/claimManagement/src/main/java/org/openimis/imisclaims/MasterDataService.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/MasterDataService.java
@@ -1,0 +1,169 @@
+package org.openimis.imisclaims;
+
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteException;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.support.annotation.NonNull;
+import android.support.v4.app.JobIntentService;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class MasterDataService extends JobIntentService {
+    private static final int JOB_ID = 32094567; //Random unique Job id
+    private static final String LOG_TAG = "MDSERVICE";
+
+    private static final String ACTION_DOWNLOAD_MD = "MasterDataService.ACTION_DOWNLOAD_MD";
+    private static final String ACTION_IMPORT_MD = "MasterDataService.ACTION_IMPORT_MD";
+
+    public static final String EXTRA_MD_URI = "MasterDataService.EXTRA_MD_URI";
+
+    public static final String ACTION_DOWNLOAD_SUCCESS = "MasterDataService.ACTION_DOWNLOAD_SUCCESS";
+    public static final String ACTION_DOWNLOAD_ERROR = "MasterDataService.ACTION_DOWNLOAD_ERROR";
+    public static final String ACTION_IMPORT_SUCCESS = "MasterDataService.ACTION_IMPORT_SUCCESS";
+    public static final String ACTION_IMPORT_ERROR = "MasterDataService.ACTION_IMPORT_ERROR";
+
+    public static final String EXTRA_ERROR_MESSAGE = "MasterDataService.EXTRA_ERROR_MESSAGE";
+
+    Global global;
+    ToRestApi toRestApi;
+    String lastAction;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        global = (Global) getApplicationContext();
+        toRestApi = new ToRestApi();
+    }
+
+    public static void downloadMasterData(Context context) {
+        Intent intent = new Intent();
+        intent.setAction(ACTION_DOWNLOAD_MD);
+        enqueueWork(context, MasterDataService.class, JOB_ID, intent);
+    }
+
+    public static void importMasterData(Context context, Uri uri) {
+        Intent intent = new Intent();
+        intent.setAction(ACTION_IMPORT_MD);
+        intent.putExtra(EXTRA_MD_URI, uri.toString());
+        enqueueWork(context, MasterDataService.class, JOB_ID, intent);
+    }
+
+    @Override
+    protected void onHandleWork(@NonNull Intent intent) {
+        lastAction = intent.getAction();
+        if (ACTION_DOWNLOAD_MD.equals(lastAction)) {
+            handleDownloadMasterData();
+        } else if (ACTION_IMPORT_MD.equals(lastAction)) {
+            Uri uri = Uri.parse(intent.getStringExtra(EXTRA_MD_URI));
+            handleImportMasterData(uri);
+        }
+
+    }
+
+    private void handleImportMasterData(Uri uri) {
+        try {
+            File tempDatabaseFile = new File(global.getSubdirectory("Databases"), "temp.db3");
+
+            if (!copyContent(uri, tempDatabaseFile)) {
+                broadcastError(ACTION_IMPORT_ERROR, getResources().getString(R.string.importMasterDataFailed));
+                tempDatabaseFile.delete();
+                return;
+            }
+
+            if (!isDatabaseValid(tempDatabaseFile)) {
+                broadcastError(ACTION_IMPORT_ERROR, getResources().getString(R.string.importMasterDataFailed));
+                tempDatabaseFile.delete();
+                return;
+            }
+
+            if (!applyDatabase(tempDatabaseFile)) {
+                broadcastError(ACTION_IMPORT_ERROR, getResources().getString(R.string.importMasterDataFailed));
+                tempDatabaseFile.delete();
+                return;
+            }
+
+            broadcastSuccess(ACTION_IMPORT_SUCCESS);
+        } catch (SQLiteException e) {
+            e.printStackTrace();
+            broadcastError(ACTION_IMPORT_ERROR, getResources().getString(R.string.importMasterDataFailed));
+        }
+    }
+
+    private void handleDownloadMasterData() {
+        //TODO not yet implemented
+    }
+
+    private void broadcastSuccess(String action) {
+        Intent successIntent = new Intent(action);
+        sendBroadcast(successIntent);
+        Log.i(LOG_TAG, String.format("%s finished with %s", lastAction, action));
+    }
+
+    private void broadcastError(String action, String errorMessage) {
+        Intent errorIntent = new Intent(action);
+        errorIntent.putExtra(EXTRA_ERROR_MESSAGE, errorMessage);
+        sendBroadcast(errorIntent);
+        Log.i(LOG_TAG, String.format("%s finished with %s, error message: %s", lastAction, action, errorMessage));
+    }
+
+    private boolean isDatabaseValid(File databaseFile) {
+        boolean isValid;
+        try (SQLiteDatabase db = SQLiteDatabase.openDatabase(databaseFile.getAbsolutePath(), null, 0)) {
+            isValid = tableExists(db, "tblControls") &&
+                    tableExists(db, "tblClaimAdmins") &&
+                    tableExists(db, "tblReferences");
+        } catch (SQLiteException e) {
+            e.printStackTrace();
+            isValid = false;
+        }
+        new File(databaseFile.getAbsolutePath() + "-journal").delete();
+        return isValid;
+    }
+
+    private boolean tableExists(SQLiteDatabase db, String table) {
+        Cursor c = db.query("sqlite_master", new String[]{"tbl_name "}, "tbl_name = ?", new String[]{table}, null, null, null);
+        boolean exists = c.getCount() > 0;
+        c.close();
+        return exists;
+    }
+
+    private boolean copyContent(Uri uri, File file) {
+        boolean databaseCopied = false;
+        try {
+            if ((!file.exists() || file.delete()) && file.createNewFile()) {
+                try (ParcelFileDescriptor fileDescriptor = getContentResolver().openFileDescriptor(uri, "r")) {
+                    long size = fileDescriptor.getStatSize();
+
+                    if (size > 0 && size < Integer.MAX_VALUE) {
+                        byte[] buff = new byte[(int) size];
+                        InputStream inputStream = getContentResolver().openInputStream(uri);
+                        if (inputStream.read(buff) == size) {
+                            new FileOutputStream(file).write(buff);
+                            databaseCopied = true;
+                        }
+                        inputStream.close();
+                    }
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return databaseCopied;
+    }
+
+    private boolean applyDatabase(File database) {
+        File imisDatabase = new File(SQLHandler.DB_NAME_DATA);
+        if (!imisDatabase.exists() || imisDatabase.delete()) {
+            return database.renameTo(imisDatabase);
+        }
+        return false;
+    }
+}

--- a/claimManagement/src/main/java/org/openimis/imisclaims/SQLHandler.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/SQLHandler.java
@@ -9,8 +9,6 @@ import android.database.sqlite.SQLiteFullException;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.util.Log;
 
-import java.nio.DoubleBuffer;
-
 import static android.database.DatabaseUtils.sqlEscapeString;
 
 /**
@@ -18,11 +16,9 @@ import static android.database.DatabaseUtils.sqlEscapeString;
  */
 
 public class SQLHandler extends SQLiteOpenHelper{
-
 	Global global;
-
-	public static final String DB_NAME_MAPPING = Global.getGlobal().getSubdirectory("Database") + "/" + "Mapping.db3";
-	public static final String DB_NAME_DATA = Global.getGlobal().getSubdirectory("Database") + "/" + "ImisData.db3";
+	public static final String DB_NAME_MAPPING = Global.getGlobal().getSubdirectory("Databases") + "/" + "Mapping.db3";
+	public static final String DB_NAME_DATA = Global.getGlobal().getSubdirectory("Databases") + "/" + "ImisData.db3";
 	private static final String CreateTable = "CREATE TABLE IF NOT EXISTS tblMapping(Code text,Name text,Type text);";
 	private static final String CreateTableControls = "CREATE TABLE IF NOT EXISTS tblControls(FieldName text, Adjustibility text);";
 	private static final String CreateTableClaimAdmins = "CREATE TABLE IF NOT EXISTS tblClaimAdmins(Code text, Name text);";
@@ -60,7 +56,7 @@ public class SQLHandler extends SQLiteOpenHelper{
 		}
 		return true;
 	}
-	public Cursor getData(String Table,String Columns[],String Criteria){
+	public Cursor getData(String Table, String[] Columns, String Criteria){
 		try {
 			//db = SQLiteDatabase.openDatabase(ClaimManagementActivity.Path + "ImisData.db3", null,SQLiteDatabase.OPEN_READONLY);
 
@@ -95,6 +91,7 @@ public class SQLHandler extends SQLiteOpenHelper{
 		}
 		return true;
 	}
+
 	public void InsertReferences(String Code,String Name,String Type, String Price){
 		try {
 			String sSQL = "";
@@ -244,35 +241,6 @@ public class SQLHandler extends SQLiteOpenHelper{
 		return Name;
 	}
 
-	public int getAllAdjustibility() {
-		int count = 0;
-		try {
-			String query = "SELECT * FROM tblControls";
-			Cursor cursor1 = db.rawQuery(query, null);
-			count = cursor1.getColumnCount();
-			// looping through all rows
-		}catch (Exception e){
-			return count;
-		}
-		return count;
-	}
-
-	public int getMaxId() {
-		int id = 1;
-		try {
-			String query = "SELECT MAX(Id) FROM tblDateUpdates";
-			Cursor cursor1 = db.rawQuery(query, null);
-			if (cursor1.moveToFirst()) {
-				do {
-					id = cursor1.getInt(0);
-				} while (cursor1.moveToNext());
-			}
-		}catch (Exception e){
-			return id;
-		}
-		return id;
-	}
-
 	public void createTables(){
 		try {
 			db.execSQL(CreateTableControls);
@@ -282,11 +250,4 @@ public class SQLHandler extends SQLiteOpenHelper{
 			e.printStackTrace();
 		}
 	}
-	public void getTables(){
-		Cursor c = db.rawQuery("SELECT name FROM sqlite_master WHERE type='table'",null);
-		if (c != null){
-			c.moveToFirst();
-		}
-	}
-
 }

--- a/claimManagement/src/main/java/org/openimis/imisclaims/SynchronizeActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/SynchronizeActivity.java
@@ -1,9 +1,12 @@
 package org.openimis.imisclaims;
 
+import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.view.MenuItem;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -11,10 +14,11 @@ import android.widget.TextView;
 import java.util.ArrayList;
 
 public class SynchronizeActivity extends ImisActivity {
+    private static final int PICK_FILE_REQUEST_CODE = 1;
     ArrayList<String> broadcastList;
 
     TextView tvUploadClaims, tvZipClaims;
-    RelativeLayout UploadClaims, zip_claims;
+    RelativeLayout uploadClaims, zipClaims, importMasterData, downloadMasterData;
 
     ProgressDialog pd;
 
@@ -33,16 +37,26 @@ public class SynchronizeActivity extends ImisActivity {
         broadcastList.add(SynchronizeService.ACTION_SYNC_ERROR);
         broadcastList.add(SynchronizeService.ACTION_EXPORT_SUCCESS);
         broadcastList.add(SynchronizeService.ACTION_EXPORT_ERROR);
+        broadcastList.add(MasterDataService.ACTION_IMPORT_ERROR);
+        broadcastList.add(MasterDataService.ACTION_IMPORT_SUCCESS);
+        broadcastList.add(MasterDataService.ACTION_DOWNLOAD_ERROR);
+        broadcastList.add(MasterDataService.ACTION_DOWNLOAD_SUCCESS);
 
 
         tvUploadClaims = findViewById(R.id.tvUploadClaims);
         tvZipClaims = findViewById(R.id.tvZipClaims);
 
-        UploadClaims = findViewById(R.id.upload_claims);
-        zip_claims = findViewById(R.id.zip_claims);
+        uploadClaims = findViewById(R.id.upload_claims);
+        zipClaims = findViewById(R.id.zip_claims);
+        importMasterData = findViewById(R.id.importMasterData);
+        downloadMasterData = findViewById(R.id.downloadMasterData);
 
-        UploadClaims.setOnClickListener(view -> doLoggedIn(this::ConfirmUploadClaims));
-        zip_claims.setOnClickListener(view -> ConfirmXMLCreation());
+        uploadClaims.setOnClickListener(view -> doLoggedIn(this::confirmUploadClaims));
+        zipClaims.setOnClickListener(view -> confirmXMLCreation());
+
+        importMasterData.setOnClickListener(view -> requestPickDatabase());
+        importMasterData.setOnClickListener(view -> {}); //TODO Not yet implemented
+
     }
 
     @Override
@@ -54,24 +68,48 @@ public class SynchronizeActivity extends ImisActivity {
     @Override
     protected void onBroadcastReceived(Context context, Intent intent) {
         String action = intent.getAction();
-        if (SynchronizeService.ACTION_CLAIM_COUNT_RESULT.equals(action)) {
-            tvUploadClaims.setText(String.valueOf(intent.getIntExtra(SynchronizeService.EXTRA_CLAIM_COUNT_PENDING, 0)));
-            tvZipClaims.setText(String.valueOf(intent.getIntExtra(SynchronizeService.EXTRA_CLAIM_COUNT_PENDING_XML, 0)));
-        } else {
-            if (SynchronizeService.ACTION_EXPORT_SUCCESS.equals(action)) {
+        String errorMessage;
+
+        switch (action) {
+            case SynchronizeService.ACTION_CLAIM_COUNT_RESULT:
+                tvUploadClaims.setText(String.valueOf(intent.getIntExtra(SynchronizeService.EXTRA_CLAIM_COUNT_PENDING, 0)));
+                tvZipClaims.setText(String.valueOf(intent.getIntExtra(SynchronizeService.EXTRA_CLAIM_COUNT_PENDING_XML, 0)));
+                break;
+            case SynchronizeService.ACTION_EXPORT_SUCCESS:
                 showDialog(getResources().getString(R.string.ZipXMLCreated));
-            } else if (SynchronizeService.ACTION_SYNC_SUCCESS.equals(action)) {
-                pd.dismiss();
+                break;
+            case SynchronizeService.ACTION_SYNC_SUCCESS:
                 showDialog(getResources().getString(R.string.BulkUpload));
-            } else if (SynchronizeService.ACTION_EXPORT_ERROR.equals(action)) {
-                String errorMessage = intent.getStringExtra(SynchronizeService.EXTRA_ERROR_MESSAGE);
+                break;
+            case SynchronizeService.ACTION_EXPORT_ERROR:
+            case SynchronizeService.ACTION_SYNC_ERROR:
+                errorMessage = intent.getStringExtra(SynchronizeService.EXTRA_ERROR_MESSAGE);
                 showDialog(errorMessage);
-            } else if (SynchronizeService.ACTION_SYNC_ERROR.equals(action)) {
-                pd.dismiss();
-                String errorMessage = intent.getStringExtra(SynchronizeService.EXTRA_ERROR_MESSAGE);
+                break;
+            case MasterDataService.ACTION_IMPORT_SUCCESS:
+                showDialog(getResources().getString(R.string.importMasterDataSuccess));
+                break;
+            case MasterDataService.ACTION_IMPORT_ERROR:
+                errorMessage = intent.getStringExtra(MasterDataService.EXTRA_ERROR_MESSAGE);
                 showDialog(errorMessage);
-            }
+                break;
+        }
+
+        if(pd!=null && pd.isShowing()) pd.dismiss();
+
+        if(!SynchronizeService.ACTION_CLAIM_COUNT_RESULT.equals(action)) {
             SynchronizeService.getClaimCount(this);
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        if (requestCode == PICK_FILE_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            Uri selectedFile = data.getData();
+            pd = ProgressDialog.show(this, "", getResources().getString(R.string.Processing));
+            MasterDataService.importMasterData(this, selectedFile);
+        } else if (requestCode == PICK_FILE_REQUEST_CODE && resultCode == Activity.RESULT_CANCELED) {
+            showToast(R.string.importMasterDataCanceled);
         }
     }
 
@@ -80,12 +118,19 @@ public class SynchronizeActivity extends ImisActivity {
         return broadcastList;
     }
 
-    public void ConfirmXMLCreation() {
+    public void confirmXMLCreation() {
         showDialog(getResources().getString(R.string.AreYouSure), (dialogInterface, i) -> exportClaims(), (dialog, id) -> dialog.cancel());
     }
 
-    public void ConfirmUploadClaims() {
+    public void confirmUploadClaims() {
         showDialog(getResources().getString(R.string.AreYouSure), (dialogInterface, i) -> uploadClaims(), (dialog, id) -> dialog.cancel());
+    }
+
+    public void requestPickDatabase() {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("application/*");
+        startActivityForResult(intent, PICK_FILE_REQUEST_CODE);
     }
 
     public boolean onOptionsItemSelected(MenuItem item) {
@@ -99,11 +144,12 @@ public class SynchronizeActivity extends ImisActivity {
     }
 
     public void uploadClaims() {
-        pd = ProgressDialog.show(this, "", getResources().getString(R.string.Uploading));
+        pd = ProgressDialog.show(this, "", getResources().getString(R.string.Processing));
         SynchronizeService.uploadClaims(this);
     }
 
     public void exportClaims() {
+        pd = ProgressDialog.show(this, "", getResources().getString(R.string.Processing));
         SynchronizeService.exportClaims(this);
     }
 }

--- a/claimManagement/src/main/res/layout/activity_synchronize.xml
+++ b/claimManagement/src/main/res/layout/activity_synchronize.xml
@@ -96,6 +96,66 @@
                 android:textColor="@color/white"
                 android:textSize="20dp" />
 
+        </RelativeLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:typeface="monospace"
+            android:fontFamily="sans-serif-light"
+            android:textSize="25dp"
+            android:layout_marginLeft="3dp"
+            android:layout_marginTop="30dp"
+            android:textColor="@color/Black"
+            android:text="@string/masterData"/>
+
+        <RelativeLayout
+            android:id="@+id/downloadMasterData"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/orange_corner"
+            android:orientation="vertical"
+            android:paddingLeft="6dp"
+            android:paddingRight="6dp"
+            android:layout_marginTop="30dp">
+
+            <TextView
+                android:id="@+id/downloadMasterDataLabel"
+                android:layout_width="match_parent"
+                android:layout_height="40dp"
+                android:background="@drawable/side_nav_bar"
+                android:fontFamily="sans-serif-light"
+                android:gravity="center"
+                android:text="@string/downloadMasterData"
+                android:textAlignment="center"
+                android:textColor="@color/white"
+                android:textSize="15dp"
+                android:typeface="monospace" />
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/importMasterData"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/orange_corner"
+            android:orientation="vertical"
+            android:paddingLeft="6dp"
+            android:paddingRight="6dp"
+            android:layout_marginTop="30dp">
+
+            <TextView
+                android:id="@+id/importMasterDataLabel"
+                android:layout_width="match_parent"
+                android:layout_height="40dp"
+                android:background="@drawable/side_nav_bar"
+                android:fontFamily="sans-serif-light"
+                android:gravity="center"
+                android:text="@string/importMasterData"
+                android:textAlignment="center"
+                android:textColor="@color/white"
+                android:textSize="15dp"
+                android:typeface="monospace" />
 
         </RelativeLayout>
 

--- a/claimManagement/src/main/res/values/strings.xml
+++ b/claimManagement/src/main/res/values/strings.xml
@@ -197,4 +197,11 @@
   <string name="initializing">Initializing…</string>
   <string name="initializing_complete">Initializing Complete</string>
   <string name="application">Application</string>
+  <string name="masterData">Master Data</string>
+  <string name="downloadMasterData">Download Master Data</string>
+  <string name="importMasterData">Import Master Data</string>
+  <string name="importMasterDataCanceled">Import canceled</string>
+  <string name="importMasterDataFailed">Import failed</string>
+  <string name="Processing">Processing…</string>
+  <string name="importMasterDataSuccess">Master Data imported successfully</string>
 </resources>


### PR DESCRIPTION
Changes:
- Created `MasterDataService` containing logic for importing master data file.
- Moved the .db3 files to private directory.
- Changed request permission to perform only one request on Android 11 instead of two.
- Added "Master Data" section to `SynchronizeActivity`, allowing for downloading and importing master data
- Changed `IntentService` to `JobIntentService` to comply with Android 11

[https://openimis.atlassian.net/browse/OTC-357](https://openimis.atlassian.net/browse/OTC-357)