### PR TITLE
OTC-405: Apply the yyyy-mm-dd date format in claims app

### DIFF
--- a/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 
 public class ClaimActivity extends AppCompatActivity {
 
@@ -317,8 +318,8 @@ public class ClaimActivity extends AppCompatActivity {
             year = Selectedyear;
             month = SelectedMonth;
             day = SelectedDay;
-
-            etStartDate.setText(new StringBuilder().append(day).append("/").append(month + 1).append("/").append(year));
+            Date date = new Date(year-1900,month,day);
+            etStartDate.setText(new SimpleDateFormat("yyyy-MM-dd", Locale.US).format(date));
 
             if(etEndDate.getText().length()==0){
                 etEndDate.setText(etStartDate.getText().toString());
@@ -333,8 +334,8 @@ public class ClaimActivity extends AppCompatActivity {
             year = SelectedYear;
             month = SelectedMonth;
             day = SelectedDay;
-
-            etEndDate.setText(new StringBuilder().append(day).append("/").append(month + 1).append("/").append(year));
+            Date date = new Date(year-1900,month,day);
+            etEndDate.setText(new SimpleDateFormat("yyyy-MM-dd", Locale.US).format(date));
         }
     };
 
@@ -538,18 +539,18 @@ public class ClaimActivity extends AppCompatActivity {
         String StartDate;
         String EndDate;
         String CurrentDate1;
-        String pattern = "dd/MM/yyyy";
+        String pattern = "yyyy-MM-dd";
 
         Date Current_date = null;
         Date Start_date = null;
         Date End_date = null;
 
-        SimpleDateFormat format = new SimpleDateFormat(pattern);
+        SimpleDateFormat format = new SimpleDateFormat(pattern, Locale.US);
 
         //CurrentDate = Date.parse(CurrentDate1);
         //StartDate = Date.parse(etStartDate.getText().toString());
         //EndDate = Date.parse(etEndDate.getText().toString());
-        CurrentDate1 = new SimpleDateFormat("dd/MM/yyyy").format(new Date());
+        CurrentDate1 = format.format(new Date());
         StartDate = etStartDate.getText().toString();
         EndDate = etEndDate.getText().toString();
 
@@ -589,7 +590,7 @@ public class ClaimActivity extends AppCompatActivity {
                 return false;
             }
             //if(tvTotal.getText().length() == 0) tvTotal.setText("0");
-            if (Float.valueOf(tvItemTotal.getText().toString()) + Float.valueOf(tvServiceTotal.getText().toString()) == 0) {
+            if (Float.parseFloat(tvItemTotal.getText().toString()) + Float.parseFloat(tvServiceTotal.getText().toString()) == 0) {
                 ShowDialog(tvItemTotal, getResources().getString(R.string.MissingClaim));
                 return false;
             }
@@ -660,7 +661,7 @@ public class ClaimActivity extends AppCompatActivity {
         File MyDir = new File(Path);
 
         //Create a file name
-        SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd");
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
         Calendar cal = Calendar.getInstance();
         String d = format.format(cal.getTime());
 
@@ -682,7 +683,7 @@ public class ClaimActivity extends AppCompatActivity {
 
             serializer.setOutput(fos, "UTF-8");
 
-            serializer.startDocument(null, Boolean.valueOf(true));
+            serializer.startDocument(null, true);
 
             serializer.setFeature("http://xmlpull.org/v1/doc/features.html#indent-output", true);
 
@@ -694,7 +695,7 @@ public class ClaimActivity extends AppCompatActivity {
 
             //ClaimDate
             serializer.startTag(null, "ClaimDate");
-            format = new SimpleDateFormat("dd/MM/yyyy");
+            format = new SimpleDateFormat("dd-MM-yyyy", Locale.US);
             d = format.format(cal.getTime());
             serializer.text(d);
             serializer.endTag(null, "ClaimDate");
@@ -873,7 +874,7 @@ public class ClaimActivity extends AppCompatActivity {
         sql.onOpen(db);
 
         //Create a file name
-        SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd");
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
         Calendar cal = Calendar.getInstance();
         String d = format.format(cal.getTime());
 
@@ -892,8 +893,6 @@ public class ClaimActivity extends AppCompatActivity {
             JSONObject FullObject = new JSONObject();
             JSONObject ClaimObject = new JSONObject();
 
-
-            format = new SimpleDateFormat("dd/MM/yyyy");
             d = format.format(cal.getTime());
             //ClaimDate
             ClaimObject.put("ClaimDate", d);

--- a/claimManagement/src/main/java/org/openimis/imisclaims/ClaimsAdapter.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ClaimsAdapter.java
@@ -68,18 +68,6 @@ public class ClaimsAdapter<VH extends TrackSelectionAdapter.ViewHolder> extends 
         _context = rContext;
         claims = _claims;
         global = (Global)rContext.getApplicationContext();
-
-        try {
-            for (int i = 0; i < _claims.length(); i++) {
-                JSONObject claim = claims.getJSONObject(i);
-                claim.put("date_claimed", parseDate(claims.getJSONObject(i).getString("date_claimed")));
-                claim.put("visit_date_from", parseDate(claims.getJSONObject(i).getString("visit_date_from")));
-                claim.put("visit_date_to", parseDate(claims.getJSONObject(i).getString("visit_date_to")));
-            }
-        } catch ( JSONException e )
-        {
-            e.printStackTrace();
-        }
     }
 
 
@@ -224,19 +212,16 @@ public class ClaimsAdapter<VH extends TrackSelectionAdapter.ViewHolder> extends 
             super(itemView);
 
 
-            itemView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    try {
-                       obj = claims.getJSONObject(getAdapterPosition());
-                    } catch (JSONException e) {
-                        e.printStackTrace();
-                    }
-                    Intent intent = new Intent(_context, ClaimReview.class);
-                    intent.putExtra("claims", String.valueOf(obj));
-                    _context.startActivity(intent);
-
+            itemView.setOnClickListener(view -> {
+                try {
+                   obj = claims.getJSONObject(getAdapterPosition());
+                } catch (JSONException e) {
+                    e.printStackTrace();
                 }
+                Intent intent = new Intent(_context, ClaimReview.class);
+                intent.putExtra("claims", String.valueOf(obj));
+                _context.startActivity(intent);
+
             });
 
             claimNo = (TextView) itemView.findViewById(R.id.claimNo);
@@ -254,28 +239,9 @@ public class ClaimsAdapter<VH extends TrackSelectionAdapter.ViewHolder> extends 
         return new AlertDialog.Builder(_context)
                 .setMessage(msg)
                 .setCancelable(false)
-                .setPositiveButton(_context.getResources().getString(R.string.Ok), new DialogInterface.OnClickListener() {
-
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        //et.requestFocus();
-                        return;
-                    }
+                .setPositiveButton(_context.getResources().getString(R.string.Ok), (dialog, which) -> {
+                    //et.requestFocus();
+                    return;
                 }).show();
-    }
-
-    private String parseDate(String date)
-    {
-        SimpleDateFormat fromApiFormat = new SimpleDateFormat("yyyy/MM/dd");
-        SimpleDateFormat databaseFormat = new SimpleDateFormat("dd/MM/yyyy");
-        String parsedDate = null;
-
-        try {
-            parsedDate = databaseFormat.format(fromApiFormat.parse(date));
-        } catch ( ParseException e ) {
-            e.printStackTrace();
-            parsedDate = date;
-        }
-        return parsedDate;
     }
 }

--- a/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
@@ -242,7 +242,7 @@ public class MainActivity extends ImisActivity {
                 (dialog, i) -> {
                     try {
                         JSONObject object1 = new JSONObject();
-                        object1.put("last_update_date", new SimpleDateFormat("yyyy/MM/dd", Locale.US).format(new Date(0)));
+                        object1.put("last_update_date", new SimpleDateFormat("yyyy-MM-dd", Locale.US).format(new Date(0)));
                         DownLoadDiagnosesServicesItemsAgain(object1, sql);
                     } catch (Exception e) {
                         e.printStackTrace();
@@ -584,7 +584,7 @@ public class MainActivity extends ImisActivity {
 
                             pd.dismiss();
                             JSONObject object = new JSONObject();
-                            SimpleDateFormat formatter = new SimpleDateFormat("yyyy/MM/dd");
+                            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
                             String dateS = formatter.format(new Date(0));
                             object.put("last_update_date", dateS);
                             try {
@@ -608,7 +608,7 @@ public class MainActivity extends ImisActivity {
 
                             pd.dismiss();
                             JSONObject object = new JSONObject();
-                            SimpleDateFormat formatter = new SimpleDateFormat("yyyy/MM/dd");
+                            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
                             String dateS = formatter.format(new Date(0));
                             object.put("last_update_date", dateS);
                             try {


### PR DESCRIPTION
Changes:
- Changed the date format to `yyyy-MM-dd`

[https://openimis.atlassian.net/browse/OTC-405](https://openimis.atlassian.net/browse/OTC-405)