### PR TITLE
OTC-433: Fix DSI rest API endpoints to allow null as last_update_date

### DIFF
--- a/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
@@ -242,7 +242,6 @@ public class MainActivity extends ImisActivity {
                 (dialog, i) -> {
                     try {
                         JSONObject object1 = new JSONObject();
-                        object1.put("last_update_date", new SimpleDateFormat("yyyy-MM-dd", Locale.US).format(new Date(0)));
                         DownLoadDiagnosesServicesItemsAgain(object1, sql);
                     } catch (Exception e) {
                         e.printStackTrace();


### PR DESCRIPTION
Changes:
- Removed `last_update_date` from `GetDiagnosesServicesItems` payload, changing '1970-01-01' to null

[https://openimis.atlassian.net/browse/OTC-433](https://openimis.atlassian.net/browse/OTC-433)