### PR TITLE
OTC-438: Adapt Claims app to get Claim response after submission

### DIFF
--- a/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
@@ -320,7 +320,6 @@ public class ClaimActivity extends ImisActivity {
 
     private void ClearForm() {
         etClaimCode.setText("");
-        etClaimAdmin.setText("");
         etGuaranteeNo.setText("");
         etCHFID.setText("");
         etStartDate.setText("");
@@ -792,98 +791,53 @@ public class ClaimActivity extends ImisActivity {
 
         try {
             JSONObject jsonObject = new JSONObject();
-            JSONObject FullObject = new JSONObject();
             JSONObject ClaimObject = new JSONObject();
 
             d = format.format(cal.getTime());
-            //ClaimDate
+
             ClaimObject.put("ClaimDate", d);
-            //HFCOde
             ClaimObject.put("HFCode", etHealthFacility.getText().toString());
-            //Claim Admin
             ClaimObject.put("ClaimAdmin", etClaimAdmin.getText().toString());
-            //ClaimCode
             ClaimObject.put("ClaimCode", etClaimCode.getText().toString());
-            //GuaranteeNo
             ClaimObject.put("GuaranteeNo", etGuaranteeNo.getText().toString());
-            //CHFID
             ClaimObject.put("CHFID", etCHFID.getText().toString());
-            //StartDate
             ClaimObject.put("StartDate", etStartDate.getText().toString());
-            //EndDate
             ClaimObject.put("EndDate", etEndDate.getText().toString());
-            //ICDCode
             ClaimObject.put("ICDCode", etDiagnosis.getText().toString());
-            //Comment
             ClaimObject.put("Comment", "");
-            //Total
             ClaimObject.put("Total", "");
-            //Diagnosis1
             ClaimObject.put("ICDCode1", etDiagnosis1.getText().toString());
-            //Diagnosis2
             ClaimObject.put("ICDCode2", etDiagnosis2.getText().toString());
-            //Diagnosis3
             ClaimObject.put("ICDCode3", etDiagnosis3.getText().toString());
-            //Diagnosis4
             ClaimObject.put("ICDCode4", etDiagnosis4.getText().toString());
-            //VisitType
             ClaimObject.put("VisitType", Rb.getTag().toString());
 
-
-            FullObject.put("Details", ClaimObject);
-            //</Details>
-
-            //Items
-            ClaimObject = new JSONObject();
-
+            jsonObject.put("details", ClaimObject);
 
             JSONArray ItemsArray = new JSONArray();
-
             for (int i = 0; i < lvItemList.size(); i++) {
-                JSONObject SubObjectItems = new JSONObject();
                 JSONObject ItemObject = new JSONObject();
-                //Code
                 ItemObject.put("ItemCode", lvItemList.get(i).get("Code"));
-                //Price
                 ItemObject.put("ItemPrice", lvItemList.get(i).get("Price"));
-                //Quantity
                 ItemObject.put("ItemQuantity", lvItemList.get(i).get("Quantity"));
-                SubObjectItems.put("Item", ItemObject);
 
-                ItemsArray.put(SubObjectItems);
-
+                ItemsArray.put(ItemObject);
             }
-            //</Items>
-            FullObject.put("Items", ItemsArray);
+            jsonObject.put("items", ItemsArray);
 
-
-            //<Services>
-            ClaimObject = new JSONObject();
 
             JSONArray ServicesArray = new JSONArray();
-
             for (int i = 0; i < lvServiceList.size(); i++) {
-                JSONObject SubObjectServices = new JSONObject();
                 JSONObject ServiceObject = new JSONObject();
-                //Code
                 ServiceObject.put("ServiceCode", lvServiceList.get(i).get("Code"));
-                //Price
                 ServiceObject.put("ServicePrice", lvServiceList.get(i).get("Price"));
-                //Quantity
                 ServiceObject.put("ServiceQuantity", lvServiceList.get(i).get("Quantity"));
-                //</Service>
-                SubObjectServices.put("Service", ServiceObject);
 
-                ServicesArray.put(SubObjectServices);
+                ServicesArray.put(ServiceObject);
             }
-            //</Services>
-            FullObject.put("Services", ServicesArray);
-
-            //</Claim>
-            jsonObject.put("Claim", FullObject);
+            jsonObject.put("services", ServicesArray);
 
             try {
-                String dir = global.getMainDirectory();
                 FileOutputStream fOut = new FileOutputStream(ClaimFile);
                 OutputStreamWriter myOutWriter = new OutputStreamWriter(fOut);
                 myOutWriter.append(jsonObject.toString());
@@ -893,13 +847,9 @@ public class ClaimActivity extends ImisActivity {
                 e.printStackTrace();
             }
 
-        } catch (IllegalStateException e) {
-            e.printStackTrace();
-        } catch (JSONException e) {
+        } catch (IllegalStateException | JSONException e) {
             e.printStackTrace();
         }
-
-
     }
 
     @Override

--- a/claimManagement/src/main/java/org/openimis/imisclaims/SynchronizeActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/SynchronizeActivity.java
@@ -7,14 +7,19 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+
 import java.util.ArrayList;
 
 public class SynchronizeActivity extends ImisActivity {
+    private static final String LOG_TAG = "SYNCACTIVITY";
     private static final int PICK_FILE_REQUEST_CODE = 1;
     ArrayList<String> broadcastList;
 
@@ -82,7 +87,23 @@ public class SynchronizeActivity extends ImisActivity {
                 showDialog(getResources().getString(R.string.ZipXMLCreated));
                 break;
             case SynchronizeService.ACTION_SYNC_SUCCESS:
-                showDialog(getResources().getString(R.string.BulkUpload));
+                try {
+                    JSONArray result = new JSONArray(intent.getStringExtra(SynchronizeService.EXTRA_CLAIM_RESPONSE));
+                    int resultLength = result.length();
+                    if (resultLength > 0) {
+                        StringBuilder builder = new StringBuilder();
+                        for (int i = 0; i < resultLength; i++) {
+                            String message = result.getString(i);
+                            builder.append(message).append("\n");
+                            Log.i(LOG_TAG, message);
+                        }
+                        showDialog(builder.toString());
+                    } else {
+                        showDialog(getResources().getString(R.string.BulkUpload));
+                    }
+                } catch (JSONException e) {
+                    Log.e(LOG_TAG, "Error while processing claim response", e);
+                }
                 break;
             case SynchronizeService.ACTION_EXPORT_ERROR:
             case SynchronizeService.ACTION_SYNC_ERROR:

--- a/claimManagement/src/main/java/org/openimis/imisclaims/SynchronizeService.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/SynchronizeService.java
@@ -17,6 +17,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.List;
 import java.util.Locale;
 
 import org.apache.http.HttpResponse;
@@ -35,6 +36,7 @@ public class SynchronizeService extends JobIntentService {
     public static final String ACTION_EXPORT_ERROR = "SynchronizeService.ACTION_EXPORT_ERROR";
     public static final String ACTION_CLAIM_COUNT_RESULT = "SynchronizeService.ACTION_CLAIM_COUNT_RESULT";
 
+    public static final String EXTRA_CLAIM_RESPONSE = "SynchronizeService.EXTRA_CLAIM_RESPONSE";
     public static final String EXTRA_ERROR_MESSAGE = "SynchronizeService.EXTRA_ERROR_MESSAGE";
     public static final String EXTRA_CLAIM_COUNT_PENDING = "SynchronizeService.EXTRA_CLAIM_COUNT_PENDING";
     public static final String EXTRA_CLAIM_COUNT_PENDING_XML = "SynchronizeService.EXTRA_CLAIM_COUNT_PENDING_XML";
@@ -44,10 +46,20 @@ public class SynchronizeService extends JobIntentService {
     private static final String claimJsonPrefix = "ClaimJSON_";
     private static final String claimXmlPrefix = "Claim_";
 
-    private static class ClaimUploadResult {
-        public static final int CLAIM_REJECTED = 0;
-        public static final int CLAIM_ACCEPTED = 1;
-        public static final int CLAIM_UPLOAD_ERROR = 2;
+    private static final String claimResponseLine = "[%s] %s";
+
+    public static class ClaimResponse {
+        public static final int Success = 2001;
+        public static final int InvalidHFCode = 2002;
+        public static final int DuplicateClaimCode = 2003;
+        public static final int InvalidInsuranceNumber = 2004;
+        public static final int EndDateIsBeforeStartDate = 2005;
+        public static final int InvalidICDCode = 2006;
+        public static final int InvalidItem = 2007;
+        public static final int InvalidService = 2008;
+        public static final int InvalidClaimAdmin = 2009;
+        public static final int Rejected = 2010;
+        public static final int UnexpectedException = 2999;
     }
 
     Global global;
@@ -59,24 +71,25 @@ public class SynchronizeService extends JobIntentService {
         super.onCreate();
         global = (Global) getApplicationContext();
         toRestApi = new ToRestApi();
+
     }
 
     public static void uploadClaims(Context context) {
         Intent intent = new Intent();
         intent.setAction(ACTION_UPLOAD_CLAIMS);
-        enqueueWork(context,SynchronizeService.class,JOB_ID,intent);
+        enqueueWork(context, SynchronizeService.class, JOB_ID, intent);
     }
 
     public static void exportClaims(Context context) {
         Intent intent = new Intent();
         intent.setAction(ACTION_EXPORT_CLAIMS);
-        enqueueWork(context,SynchronizeService.class,JOB_ID,intent);
+        enqueueWork(context, SynchronizeService.class, JOB_ID, intent);
     }
 
     public static void getClaimCount(Context context) {
         Intent intent = new Intent();
         intent.setAction(ACTION_CLAIM_COUNT);
-        enqueueWork(context,SynchronizeService.class,JOB_ID,intent);
+        enqueueWork(context, SynchronizeService.class, JOB_ID, intent);
     }
 
     @Override
@@ -92,100 +105,59 @@ public class SynchronizeService extends JobIntentService {
     }
 
     private void handleUploadClaims() {
-        String errorMessage;
+        if (!global.isNetworkAvailable()) {
+            broadcastError(ACTION_SYNC_ERROR, getResources().getString(R.string.CheckInternet));
+            return;
+        }
 
         File pendingDirectory = new File(global.getMainDirectory());
         ArrayList<File> jsonClaims = new ArrayList<>(Arrays.asList(getListOfFilesPrefix(pendingDirectory, claimJsonPrefix)));
+        JSONArray claims = loadClaims(jsonClaims);
 
-        if (jsonClaims.size() < 1) {
+        if (claims.length() < 1) {
             broadcastError(ACTION_SYNC_ERROR, getResources().getString(R.string.NoClaim));
-        } else if (!global.isNetworkAvailable()) {
-            broadcastError(ACTION_SYNC_ERROR, getResources().getString(R.string.CheckInternet));
-        } else {
-            boolean errorOccurred = false;
-            for (File claimFile : jsonClaims) {
-                String claim = global.getFileText(claimFile);
+            return;
+        }
 
-                JSONObject obj = null;
+        HttpResponse response = toRestApi.postToRestApiToken(claims, "claim");
+        if (response != null) {
+            int statusCode = response.getStatusLine().getStatusCode();
+            String errorMessage = getErrorMessage(statusCode);
 
-                try {
-                    JSONObject jo = new JSONObject(claim);
-                    JSONObject jobj = jo.getJSONObject("Claim");
-
-                    JSONObject datailsObj = jobj.getJSONObject("Details");
-                    JSONArray itemsArray = jobj.getJSONArray("Items");
-                    JSONArray servicesArray = jobj.getJSONArray("Services");
-
-                    JSONArray itemsArrayRes = new JSONArray();
-                    for (int k = 0; k < itemsArray.length(); k++) {
-                        itemsArrayRes.put(itemsArray.getJSONObject(k).getJSONObject("Item"));
-                    }
-
-                    JSONArray servicesArrayRes = new JSONArray();
-                    for (int k = 0; k < servicesArray.length(); k++) {
-                        servicesArrayRes.put(servicesArray.getJSONObject(k).getJSONObject("Service"));
-                    }
-
-                    obj = new JSONObject();
-                    obj.put("details", datailsObj);
-                    obj.put("items", itemsArrayRes);
-                    obj.put("services", servicesArrayRes);
-
-                    HttpResponse response = toRestApi.postToRestApiToken(obj, "claim");
-
-                    if (response == null) {
-                        errorMessage = getResources().getString(R.string.CheckInternet);
-                    } else {
-                        errorMessage = getErrorMessage(response.getStatusLine().getStatusCode());
-                    }
-
-                    if (!"".equals(errorMessage)) {
-                        broadcastError(ACTION_SYNC_ERROR, errorMessage);
-                        errorOccurred = true;
-                        break;
-                    } else {
-                        String content = toRestApi.getContent(response);
-
-                        if (content != null && !"".equals(content)) {
-                            int resInt = Integer.parseInt(content);
-
-                            switch (resInt) {
-                                case ClaimUploadResult.CLAIM_ACCEPTED: {
-                                    MoveFileToSubdirectory(claimFile, "AcceptedClaims");
-                                    File xmlFile = new File(claimFile.getAbsolutePath().replace(claimJsonPrefix, claimXmlPrefix).replace(".txt", ".xml"));
-                                    if (xmlFile.exists()) {
-                                        MoveFileToSubdirectory(xmlFile, "AcceptedClaims");
-                                    }
-                                    break;
-                                }
-                                case ClaimUploadResult.CLAIM_REJECTED: {
-                                    MoveFileToSubdirectory(claimFile, "RejectedClaims");
-                                    File xmlFile = new File(claimFile.getAbsolutePath().replace(claimJsonPrefix, claimXmlPrefix).replace(".txt", ".xml"));
-                                    if (xmlFile.exists()) {
-                                        MoveFileToSubdirectory(xmlFile, "RejectedClaims");
-                                    }
-                                    break;
-                                }
-                                default: {
-                                    broadcastError(ACTION_SYNC_ERROR, getResources().getString(R.string.ErrorOccurred));
-                                    errorOccurred = true;
-                                }
-                            }
-                            if (errorOccurred) break;
-                        }
-                    }
-
-                } catch (JSONException e) {
-                    e.printStackTrace();
-                    broadcastError(ACTION_SYNC_ERROR, e.getMessage());
-                    errorOccurred = true;
-                    break;
-                }
+            if (errorMessage != null) {
+                broadcastError(ACTION_SYNC_ERROR, errorMessage);
+                return;
             }
-            if (!errorOccurred) {
-                broadcastSuccess(ACTION_SYNC_SUCCESS);
+
+            try {
+                String responseContent = toRestApi.getContent(response);
+                JSONArray claimResponseArray = new JSONArray(responseContent);
+                JSONArray claimStatus = processClaimResponse(claimResponseArray);
+                broadcastSyncSuccess(claimStatus);
+            } catch (JSONException e) {
+                Log.e(LOG_TAG, "Error while processing claim response", e);
+                broadcastError(ACTION_SYNC_ERROR, getResources().getString(R.string.ErrorOccurred));
             }
         }
+    }
+
+    private JSONArray processClaimResponse(JSONArray claimResponseArray) throws JSONException {
+        JSONArray result = new JSONArray();
+
+        for (int i = 0; i < claimResponseArray.length(); i++) {
+            JSONObject claimResponse = claimResponseArray.getJSONObject(i);
+            String claimCode = claimResponse.getString("claimCode");
+            int claimResponseCode = claimResponse.getInt("response");
+
+            if (claimResponseCode == ClaimResponse.Success) {
+                moveClaimToSubdirectory(claimCode, "AcceptedClaims");
+            } else if (claimResponseCode == ClaimResponse.Rejected) {
+                moveClaimToSubdirectory(claimCode, "RejectedClaims");
+            } else {
+                result.put(String.format(claimResponseLine, claimCode, claimResponse.getString("message")));
+            }
+        }
+        return result;
     }
 
     private void handleExportClaims() {
@@ -204,14 +176,14 @@ public class SynchronizeService extends JobIntentService {
             Compressor.zip(xmlClaims, zipFilePath, password);
 
             for (File f : xmlClaims) {
-                MoveFileToSubdirectory(f, "Trash");
+                moveFileToSubdirectory(f, "Trash");
             }
 
             for (File f : jsonClaims) {
-                MoveFileToSubdirectory(f, "Trash");
+                moveFileToSubdirectory(f, "Trash");
             }
 
-            broadcastSuccess(ACTION_EXPORT_SUCCESS);
+            broadcastExportSuccess();
         } else {
             broadcastError(ACTION_EXPORT_ERROR, getResources().getString(R.string.NoClaim));
         }
@@ -231,21 +203,37 @@ public class SynchronizeService extends JobIntentService {
     }
 
     private String getErrorMessage(int responseCode) {
-        String errorMessage;
+        String errorMessage = null;
         if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
             errorMessage = getResources().getString(R.string.has_no_rights);
         } else if (responseCode == HttpURLConnection.HTTP_INTERNAL_ERROR) {
             errorMessage = getResources().getString(R.string.SomethingWrongServer);
         } else if (responseCode >= 400) {
             errorMessage = getResources().getString(R.string.SomethingWrongServer);
-        } else {
-            errorMessage = "";
         }
         return errorMessage;
     }
 
+    private void moveClaimToSubdirectory(String claimCode, String subDirectory) {
+        File pendingDirectory = new File(global.getMainDirectory());
+        File[] files = getListOfFilesForClaim(pendingDirectory, claimCode);
+        for (File f : files) {
+            moveFileToSubdirectory(f, subDirectory);
+        }
+    }
+
     private File[] getListOfFilesPrefix(File directory, String prefix) {
         FilenameFilter filter = (dir, filename) -> filename.startsWith(prefix);
+        return directory.listFiles(filter);
+    }
+
+    private File[] getListOfFilesForClaim(File directory, String claimCode) {
+        String regex = ".+_.+_" + claimCode + "_";
+        return getListOfFilesMatching(directory, regex);
+    }
+
+    private File[] getListOfFilesMatching(File directory, String regex) {
+        FilenameFilter filter = (dir, filename) -> filename.matches(regex);
         return directory.listFiles(filter);
     }
 
@@ -254,21 +242,46 @@ public class SynchronizeService extends JobIntentService {
         return listOfFiles != null ? listOfFiles.length : 0;
     }
 
-    private void MoveFileToSubdirectory(File file, String subdirectory) {
-        file.renameTo(new File(global.getSubdirectory(subdirectory), file.getName()));
+    private void moveFileToSubdirectory(File file, String subdirectory) {
+        if (!file.renameTo(new File(global.getSubdirectory(subdirectory), file.getName()))) {
+            Log.e(LOG_TAG, String.format("Moving a file to %s failed: %s", subdirectory, file.getAbsolutePath()));
+        }
     }
 
-    private void broadcastSuccess(String action) {
-        Intent successIntent = new Intent(action);
+    private JSONArray loadClaims(List<File> files) {
+        try {
+            JSONArray claims = new JSONArray();
+            for (File claimFile : files) {
+                String claim = global.getFileText(claimFile);
+                JSONObject claimObject = new JSONObject(claim);
+                claims.put(claimObject);
+            }
+            return claims;
+        } catch (JSONException e) {
+            Log.e(LOG_TAG, "Error while loading claims", e);
+            return new JSONArray();
+        }
+    }
+
+    private void broadcastSyncSuccess(JSONArray claimResponse) {
+        Intent successIntent = new Intent(ACTION_SYNC_SUCCESS);
+        successIntent.putExtra(EXTRA_CLAIM_RESPONSE, claimResponse.toString());
         sendBroadcast(successIntent);
-        Log.i(LOG_TAG, String.format("%s finished with %s",lastAction,action));
+        Log.i(LOG_TAG, String.format("%s finished with %s, messages count: %d", lastAction, ACTION_SYNC_SUCCESS, claimResponse.length()));
+    }
+
+
+    private void broadcastExportSuccess() {
+        Intent successIntent = new Intent(ACTION_EXPORT_SUCCESS);
+        sendBroadcast(successIntent);
+        Log.i(LOG_TAG, String.format("%s finished with %s", lastAction, ACTION_EXPORT_SUCCESS));
     }
 
     private void broadcastError(String action, String errorMessage) {
         Intent errorIntent = new Intent(action);
         errorIntent.putExtra(EXTRA_ERROR_MESSAGE, errorMessage);
         sendBroadcast(errorIntent);
-        Log.i(LOG_TAG,String.format("%s finished with %s, error message: %s",lastAction,action,errorMessage));
+        Log.i(LOG_TAG, String.format("%s finished with %s, error message: %s", lastAction, action, errorMessage));
     }
 
     private void broadcastClaimCount(int pending, int accepted, int rejected, int pendingXml) {
@@ -278,6 +291,6 @@ public class SynchronizeService extends JobIntentService {
         resultIntent.putExtra(EXTRA_CLAIM_COUNT_REJECTED, rejected);
         resultIntent.putExtra(EXTRA_CLAIM_COUNT_PENDING_XML, pendingXml);
         sendBroadcast(resultIntent);
-        Log.i(LOG_TAG,String.format("%s finished with %s, result:  p: %d,a: %d,r: %d,pxml: %d",lastAction,ACTION_CLAIM_COUNT_RESULT,pending,accepted,rejected,pendingXml));
+        Log.i(LOG_TAG, String.format("%s finished with %s, result:  p: %d,a: %d,r: %d,pxml: %d", lastAction, ACTION_CLAIM_COUNT_RESULT, pending, accepted, rejected, pendingXml));
     }
 }

--- a/claimManagement/src/main/java/org/openimis/imisclaims/ToRestApi.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ToRestApi.java
@@ -48,7 +48,7 @@ public class ToRestApi {
         }
     }
 
-    public HttpResponse postToRestApi(JSONObject object, String functionName, boolean addToken) {
+    public HttpResponse postToRestApi(Object object, String functionName, boolean addToken) {
         HttpClient httpClient = new DefaultHttpClient();
 
         HttpPost httpPost = new HttpPost(uri + functionName);
@@ -71,11 +71,11 @@ public class ToRestApi {
         }
     }
 
-    public HttpResponse postToRestApi(JSONObject object, String functionName) {
+    public HttpResponse postToRestApi(Object object, String functionName) {
         return postToRestApi(object, functionName, false);
     }
 
-    public HttpResponse postToRestApiToken(JSONObject object, String functionName) {
+    public HttpResponse postToRestApiToken(Object object, String functionName) {
         return postToRestApi(object, functionName, true);
     }
 


### PR DESCRIPTION
Changes:
- Simplified claim json serializer.
- Added status popup with every error message during claim submission (from claim response).
- Changed claim synchronization to send all claims in one call.
- Changed `ToRestApi` post object type to `Object` to allow for json arrays

[https://openimis.atlassian.net/browse/OTC-438](https://openimis.atlassian.net/browse/OTC-438)