### PR TITLE
OTC-445: MV IMIS Claims: replies with Invalid Claim Code in the initial page

### DIFF
--- a/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
@@ -530,12 +530,12 @@ public class MainActivity extends ImisActivity {
 
     public void validateClaimAdminCode(final String ClaimCode) {
         if (ClaimCode.equals("")) {
-            Toast.makeText(getBaseContext(), R.string.MissingClaimCode, Toast.LENGTH_LONG).show();
+            Toast.makeText(getBaseContext(), R.string.MissingClaimAdmin, Toast.LENGTH_LONG).show();
             ClaimAdminDialogBox();
         } else {
             String ClaimName = sqlHandler.getClaimAdmin(ClaimCode);
             if (ClaimName.equals("")) {
-                Toast.makeText(MainActivity.this, getResources().getString(R.string.invalid_code), Toast.LENGTH_LONG).show();
+                Toast.makeText(MainActivity.this, getResources().getString(R.string.invalidClaimAdminCode), Toast.LENGTH_LONG).show();
                 ClaimAdminDialogBox();
             } else {
                 if (!sqlHandler.getAdjustibility("ClaimAdministrator").equals("N")) {

--- a/claimManagement/src/main/res/values/strings.xml
+++ b/claimManagement/src/main/res/values/strings.xml
@@ -204,4 +204,5 @@
   <string name="importMasterDataFailed">Import failed</string>
   <string name="Processing">Processing…</string>
   <string name="importMasterDataSuccess">Master Data imported successfully</string>
+  <string name="invalidClaimAdminCode">Invalid Claim Admin Code</string>
 </resources>


### PR DESCRIPTION
Changes:
- Fixed prompts used in claim admin dialog box to mention "Claim Admin" instead of "Claim"

[https://openimis.atlassian.net/browse/OTC-445](https://openimis.atlassian.net/browse/OTC-445)