### PR TITLE
OTC-375: Show message before requesting authorization to memory

### DIFF
--- a/claimManagement/src/main/AndroidManifest.xml
+++ b/claimManagement/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission
         android:name="android.permission.READ_CALL_LOG"
         tools:node="remove" />
@@ -25,21 +27,21 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher_round"
         android:label="@string/app_name_claims"
-        android:requestLegacyExternalStorage="true"
         android:networkSecurityConfig="@xml/network_security_config"
+        android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:replace="android:icon,android:label">
         <service
             android:name=".SynchronizeService"
-            android:permission="android.permission.BIND_JOB_SERVICE"
-            android:exported="true"/>
+            android:exported="true"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
 
         <service
             android:name=".MasterDataService"
-            android:permission="android.permission.BIND_JOB_SERVICE"
-            android:exported="true"/>
+            android:exported="true"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
 
         <uses-library
             android:name="org.apache.http.legacy"
@@ -90,8 +92,7 @@
             android:configChanges="orientation|keyboardHidden"
             android:screenOrientation="landscape"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-            android:windowSoftInputMode="stateAlwaysHidden">
-        </activity>
+            android:windowSoftInputMode="stateAlwaysHidden"></activity>
 
         <uses-library
             android:name="org.apache.http.legacy"

--- a/claimManagement/src/main/java/org/openimis/imisclaims/Global.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/Global.java
@@ -25,12 +25,14 @@
 
 package org.openimis.imisclaims;
 
+import android.Manifest;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.os.Build;
 import android.os.Environment;
 import android.util.Base64;
 import android.util.DisplayMetrics;
@@ -70,12 +72,23 @@ public class Global extends Application {
     private final Map<String, String> SubDirectories = new HashMap<>();
     private static final String _DefaultRarPassword = RAR_PASSWORD;
     private Token JWTToken;
+    private String[] permissions;
 
     private final List<String> ProtectedDirectories = Arrays.asList("Authentications", "Databases");
 
-
     public Global() {
         instance = this;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            permissions = new String[]{Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.VIBRATE, Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.INTERNET, Manifest.permission.CAMERA, Manifest.permission.ACCESS_NETWORK_STATE, Manifest.permission.ACCESS_WIFI_STATE, Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.CHANGE_WIFI_STATE, Manifest.permission.MANAGE_EXTERNAL_STORAGE};
+        } else {
+            permissions = new String[]{Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.VIBRATE, Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.INTERNET, Manifest.permission.CAMERA, Manifest.permission.ACCESS_NETWORK_STATE, Manifest.permission.ACCESS_WIFI_STATE, Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.CHANGE_WIFI_STATE};
+        }
+
     }
 
     public static Global getGlobal() {
@@ -112,6 +125,10 @@ public class Global extends Application {
 
     public String getOfficeName() {
         return this.OfficerName;
+    }
+
+    public String[] getPermissions() {
+        return permissions;
     }
 
     public Token getJWTToken() {

--- a/claimManagement/src/main/java/org/openimis/imisclaims/SQLHandler.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/SQLHandler.java
@@ -1,5 +1,6 @@
 package org.openimis.imisclaims;
 
+import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.SQLException;
@@ -8,12 +9,6 @@ import android.database.sqlite.SQLiteFullException;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.text.TextUtils;
 import android.util.Log;
-
-import static android.database.DatabaseUtils.sqlEscapeString;
-
-/**
- * Created by user on 10/01/2018.
- */
 
 public class SQLHandler extends SQLiteOpenHelper {
     public static final String DB_NAME_MAPPING = Global.getGlobal().getSubdirectory("Databases") + "/" + "Mapping.db3";
@@ -89,9 +84,12 @@ public class SQLHandler extends SQLiteOpenHelper {
 
     public boolean InsertMapping(String Code, String Name, String Type) {
         try {
-            String sSQL = "";
-            sSQL = "INSERT INTO tblMapping(Code,Name,Type)VALUES('" + Code.replace("'", "''") + "','" + Name.replace("'", "''") + "','" + Type + "')";
-            dbMapping.execSQL(sSQL);
+            ContentValues cv = new ContentValues();
+            cv.put("Code", Code);
+            cv.put("Name", Name);
+            cv.put("Type", Type);
+
+            dbMapping.insert("tblMapping", null, cv);
         } catch (SQLiteFullException e) {
             return false;
         }
@@ -100,20 +98,24 @@ public class SQLHandler extends SQLiteOpenHelper {
 
     public void InsertReferences(String Code, String Name, String Type, String Price) {
         try {
-            String sSQL = "";
-            sSQL = "INSERT INTO tblReferences(Code,Name,Type,Price)VALUES(\"" + Code + "\",\"" + Name + "\",\"" + Type + "\",\"" + Price + "\")";
-            db.execSQL(sSQL);
+            ContentValues cv = new ContentValues();
+            cv.put("Code", Code);
+            cv.put("Name", Name);
+            cv.put("Type", Type);
+            cv.put("Price", Price);
+
+            db.insert("tblReferences", null, cv);
         } catch (Exception e) {
             e.printStackTrace();
-
         }
     }
 
     public void InsertControls(String FieldName, String Adjustibility) {
         try {
-            String sSQL = "";
-            sSQL = "INSERT INTO tblControls(FieldName,Adjustibility)VALUES('" + FieldName + "','" + Adjustibility + "')";
-            db.execSQL(sSQL);
+            ContentValues cv = new ContentValues();
+            cv.put("FieldName", FieldName);
+            cv.put("Adjustibility", Adjustibility);
+            db.insert("tblControls", null, cv);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -121,31 +123,26 @@ public class SQLHandler extends SQLiteOpenHelper {
 
     public void InsertClaimAdmins(String Code, String Name) {
         try {
-            String sSQL = "";
-            sSQL = "INSERT INTO tblClaimAdmins(Code,Name)VALUES(" + sqlEscapeString(Code) + "," + sqlEscapeString(Name) + ")";
-            db.execSQL(sSQL);
+            ContentValues cv = new ContentValues();
+            cv.put("Code", Code);
+            cv.put("Name", Name);
+            db.insert("tblClaimAdmins", null, cv);
         } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
     public void ClearMapping(String Type) {
-        String sSQL = "";
-        sSQL = "DELETE FROM tblMapping WHERE TYpe = '" + Type + "'";
-        dbMapping.execSQL(sSQL);
+        dbMapping.delete("tblMapping", "Type = ?", new String[]{Type});
     }
 
     public void ClearReferencesSI() {
-        String sSQL = "";
-        sSQL = "DELETE FROM tblReferences WHERE Type != 'D'";
-        db.execSQL(sSQL);
+        db.delete("tblReferences", "Type != ?", new String[]{"D"});
     }
 
     public void ClearAll(String tblName) {
         try {
-            String sSQL = "";
-            sSQL = "DELETE FROM " + tblName + "";
-            db.execSQL(sSQL);
+            db.delete(tblName, null, null);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/claimManagement/src/main/res/values/strings.xml
+++ b/claimManagement/src/main/res/values/strings.xml
@@ -206,4 +206,8 @@
   <string name="importMasterDataSuccess">Master Data imported successfully</string>
   <string name="invalidClaimAdminCode">Invalid Claim Admin Code</string>
   <string name="Logout">Logout</string>
+  <string name="ExternalStorageAccess">External Storage Access</string>
+  <string name="ExternalStorageAccessInfo">To work correctly, %1$s requires external storage access. Please allow it for %1$s in next screen in order to use the application.</string>
+  <string name="Permissions">Permissions</string>
+  <string name="PermissionsInfo">To work correctly, %1$s requires multiple permissions. Please allow them in next screen in order to use the application.</string>
 </resources>


### PR DESCRIPTION
Changes:
- Added dialogs before permission request and external memory access (A11)
- Changed Initialization process to be sequential (For the app to recieve permissions before downloading data)
- Simplified SQLHandler insert and delete helper methods

[https://openimis.atlassian.net/browse/OTC-375](https://openimis.atlassian.net/browse/OTC-375)