### PR TITLE
OP-465: Fixed moving claim files after sync

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,10 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
-
+        classpath 'com.android.tools.build:gradle:7.0.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -18,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/claimManagement/build.gradle
+++ b/claimManagement/build.gradle
@@ -3,8 +3,6 @@ import java.time.format.DateTimeFormatter
 
 apply plugin: 'com.android.application'
 
-// Apply custom flavours
-
 static def getDate() {
     LocalDateTime date = LocalDateTime.now()
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern('dd MMMM yyyy HH:mm').withLocale(Locale.UK)
@@ -147,7 +145,7 @@ android {
         chfDev.res.srcDir 'src/chfDev/res'
 
         chfProd.java.srcDir 'src/chfDev/java'
-        chfProd.res.srcDir 'src/chfProd/res'
+        chfProd.res.srcDir 'src/chfDev/res'
 
         mvDev.java.srcDir 'src/mvDev/java'
         mvDev.res.srcDir 'src/mvDev/res'
@@ -174,11 +172,12 @@ android {
 
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 }
 
+// Apply custom flavours
 if(file('custom-flavours.gradle').exists()){
     apply from: 'custom-flavours.gradle'
 }

--- a/claimManagement/src/main/AndroidManifest.xml
+++ b/claimManagement/src/main/AndroidManifest.xml
@@ -15,12 +15,6 @@
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission
-        android:name="android.permission.READ_CALL_LOG"
-        tools:node="remove" />
-    <uses-permission
-        android:name="android.permission.READ_CONTACTS"
-        tools:node="remove" />
 
     <application
         android:name=".Global"
@@ -50,6 +44,7 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name_claims"
+            android:exported="true"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -92,7 +87,7 @@
             android:configChanges="orientation|keyboardHidden"
             android:screenOrientation="landscape"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-            android:windowSoftInputMode="stateAlwaysHidden"></activity>
+            android:windowSoftInputMode="stateAlwaysHidden" />
 
         <uses-library
             android:name="org.apache.http.legacy"

--- a/claimManagement/src/main/java/org/openimis/imisclaims/SynchronizeService.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/SynchronizeService.java
@@ -228,7 +228,8 @@ public class SynchronizeService extends JobIntentService {
     }
 
     private File[] getListOfFilesForClaim(File directory, String claimCode) {
-        String regex = ".+_.+_" + claimCode + "_";
+        //Example file structure: "Claim_hfcode_claimcode_date.xml"
+        String regex = String.format("(%s|%s).+_%s_.*", claimJsonPrefix, claimXmlPrefix, claimCode);
         return getListOfFilesMatching(directory, regex);
     }
 

--- a/claimManagement/src/main/java/org/openimis/imisclaims/ToRestApi.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ToRestApi.java
@@ -10,14 +10,15 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
-import org.json.JSONObject;
 
 import java.io.IOException;
 
 import static org.openimis.imisclaims.BuildConfig.API_BASE_URL;
 import static org.openimis.imisclaims.BuildConfig.API_VERSION;
+import static java.lang.Math.min;
 
 public class ToRestApi {
+    private static final String LOG_TAG = "HTTP";
     private final Token token;
     private final String uri;
     private final String apiVersion;
@@ -38,9 +39,13 @@ public class ToRestApi {
         }
 
         try {
+            Log.i(LOG_TAG, String.format("request: GET %s%s", uri, functionName));
+
             HttpResponse response = httpClient.execute(httpGet);
             int responseCode = response.getStatusLine().getStatusCode();
-            Log.i("HTTP_GET", uri + functionName + " - " + responseCode);
+            String responsePhrase = response.getStatusLine().getReasonPhrase();
+            Log.i(LOG_TAG, String.format("response: %d %s", responseCode, responsePhrase));
+
             return response;
         } catch (IOException e) {
             e.printStackTrace();
@@ -59,11 +64,17 @@ public class ToRestApi {
         }
 
         try {
-            StringEntity postingString = new StringEntity(object.toString());
+            String entity = object.toString();
+            StringEntity postingString = new StringEntity(entity);
             httpPost.setEntity(postingString);
+            Log.i(LOG_TAG, String.format("request: POST %s%s", uri, functionName));
+            Log.v(LOG_TAG, "request content: " + entity.substring(0, min(entity.length(), 1000)));
+
             HttpResponse response = httpClient.execute(httpPost);
             int responseCode = response.getStatusLine().getStatusCode();
-            Log.i("HTTP_POST", uri + functionName + " - " + responseCode);
+            String responsePhrase = response.getStatusLine().getReasonPhrase();
+            Log.i(LOG_TAG, String.format("response: %d %s", responseCode, responsePhrase));
+
             return response;
         } catch (IOException e) {
             e.printStackTrace();
@@ -92,10 +103,14 @@ public class ToRestApi {
     public String getContent(HttpResponse response) {
         try {
             HttpEntity respEntity = (response != null) ? response.getEntity() : null;
-            return (respEntity != null) ? EntityUtils.toString(respEntity) : null;
+            String content = (respEntity != null) ? EntityUtils.toString(respEntity) : null;
+            Log.v(LOG_TAG, "response content: " + (content != null ? content.substring(0, min(content.length(), 1000)) : "null"));
+            return content;
         } catch (IOException e) {
-            e.printStackTrace();
+            Log.e(LOG_TAG, "Error when extracting response body", e);
             return null;
         }
     }
+
+
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 24 09:49:27 EAT 2018
+#Fri Dec 03 10:17:47 CET 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Changes:
- Fixed regex used to pick files related to specific claim
- Extended logging in `ToRestApi`

Maintenance:
- Bumped `Java` version to `11`
- Bumped `Gradle` version to `7.0.2`
- Replaced `Jcenter` repository with `Maven`
- Removed unused permissions

[https://openimis.atlassian.net/browse/OP-465](https://openimis.atlassian.net/browse/OP-465)