### PR TITLE
OTC-587: Null on the claim admin application

### DIFF
--- a/claimManagement/src/main/java/org/openimis/imisclaims/ImisActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ImisActivity.java
@@ -175,8 +175,9 @@ public abstract class ImisActivity extends AppCompatActivity {
         final TextView username = promptsView.findViewById(R.id.UserName);
         final TextView password = promptsView.findViewById(R.id.Password);
 
+
         String officer_code = ((Global) getApplicationContext()).getOfficerCode();
-        username.setText(String.valueOf(officer_code));
+        username.setText(officer_code != null ? officer_code : "");
 
         // set dialog message
         alertDialogBuilder

--- a/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
@@ -517,8 +517,8 @@ public class MainActivity extends ImisActivity {
             Toast.makeText(getBaseContext(), R.string.MissingClaimAdmin, Toast.LENGTH_LONG).show();
             ClaimAdminDialogBox();
         } else {
-            String ClaimName = sqlHandler.getClaimAdminInfo(claimAdminCode, sqlHandler.CA_NAME_COLUMN);
-            String HealthFacilityName = sqlHandler.getClaimAdminInfo(claimAdminCode, sqlHandler.CA_HF_CODE_COLUMN);
+            String ClaimName = sqlHandler.getClaimAdminInfo(claimAdminCode, SQLHandler.CA_NAME_COLUMN);
+            String HealthFacilityName = sqlHandler.getClaimAdminInfo(claimAdminCode, SQLHandler.CA_HF_CODE_COLUMN);
             if (ClaimName.equals("")) {
                 Toast.makeText(MainActivity.this, getResources().getString(R.string.invalidClaimAdminCode), Toast.LENGTH_LONG).show();
                 ClaimAdminDialogBox();
@@ -527,7 +527,7 @@ public class MainActivity extends ImisActivity {
                     global.setOfficerCode(claimAdminCode);
                     global.setOfficerName(ClaimName);
                     global.setOfficerHealthFacility(HealthFacilityName);
-                    AdminName = (TextView) findViewById(R.id.AdminName);
+                    AdminName = findViewById(R.id.AdminName);
                     AdminName.setText(global.getOfficeName());
                     Cursor c = sqlHandler.getMapping("I");
                     if (c.getCount() == 0) {

--- a/claimManagement/src/main/java/org/openimis/imisclaims/SQLHandler.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/SQLHandler.java
@@ -254,9 +254,8 @@ public class SQLHandler extends SQLiteOpenHelper {
 
     public String getClaimAdminInfo(String Code, String column) {
         String Info = "";
-        try {
-            String query = "SELECT " + column + " FROM tblClaimAdmins WHERE upper(Code) like '" + Code.toUpperCase() + "'";
-            Cursor cursor1 = db.rawQuery(query, null);
+        String query = "SELECT " + column + " FROM tblClaimAdmins WHERE upper(Code) like '" + Code.toUpperCase() + "'";
+        try (Cursor cursor1 = db.rawQuery(query, null)){
             // looping through all rows
             if (cursor1.moveToFirst()) {
                 do {

--- a/claimManagement/src/main/res/menu/activity_main_drawer.xml
+++ b/claimManagement/src/main/res/menu/activity_main_drawer.xml
@@ -41,17 +41,17 @@
             android:icon="@drawable/mapservices"
             android:title="@string/retrieve" />
         <item
-            android:id="@+id/nav_quit"
-            android:icon="@drawable/ic_quit1"
-            android:title="@string/quit" />
+            android:id="@+id/nav_settings"
+            android:icon="@drawable/settings"
+            android:title="@string/settings" />
         <item
             android:id="@+id/nav_about"
             android:icon="@drawable/ic_about1"
             android:title="@string/about" />
         <item
-            android:id="@+id/nav_settings"
-            android:icon="@drawable/settings"
-            android:title="@string/settings" />
+            android:id="@+id/nav_quit"
+            android:icon="@drawable/ic_quit1"
+            android:title="@string/quit" />
     </group>
 
 </menu>


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OTC-587](https://openimis.atlassian.net/browse/OTC-587)

Changes:
- Fixed error when accessing login prompt without claim admin information would result with "null" string inside the username field. Now if the user info is missing, the username field will be empty
- Fixed missing cursor handling in `getClaimAdminInfo`
- Minor code improvements