### PR TITLE
test ClaimActivity.saveClaim

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ on:
       - '*'
 #    tags:
 #      - '!v*'
+  pull_request:
+    branches:
+      - '*'
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:

--- a/claimManagement/build.gradle
+++ b/claimManagement/build.gradle
@@ -180,6 +180,12 @@ android {
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES'
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 apollo {
@@ -193,6 +199,13 @@ apollo {
     ]
 }
 
+tasks.withType(Test).configureEach {
+    testLogging {
+        events "passed", "skipped", "failed"
+        exceptionFormat "full"
+        showStandardStreams = false
+    }
+}
 
 // Apply custom flavours
 if(file('custom-flavours.gradle').exists()){
@@ -215,9 +228,13 @@ dependencies {
     implementation ('com.apollographql.apollo:apollo-android-support:2.5.14'){
         because("Apollo 3+ only works with Kotlin coroutines")
     }
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.5.0'
+    testImplementation 'org.robolectric:robolectric:4.11.1'
+    testImplementation 'androidx.test:core:1.5.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test:core:1.5.0'
     implementation group: 'com.squareup.picasso', name: 'picasso', version: '2.71828'
     implementation group: 'net.lingala.zip4j', name: 'zip4j', version: '1.2.7'
 

--- a/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
@@ -811,7 +811,7 @@ public class ClaimActivity extends ImisActivity {
         runOnUiThread(() -> showDialog(msg, (dialog, which) -> ClearForm(), (dialog, which) -> dialog.dismiss()));
     }
 
-    private boolean saveClaim() {
+    protected boolean saveClaim() {
         Intent intent = getIntent();
         String claimUUID;
         if (intent.hasExtra(EXTRA_CLAIM_UUID)) {

--- a/claimManagement/src/test/java/org/openimis/imisclaims/ClaimActivityTest.java
+++ b/claimManagement/src/test/java/org/openimis/imisclaims/ClaimActivityTest.java
@@ -1,0 +1,139 @@
+package org.openimis.imisclaims;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import android.app.Activity;
+import android.content.ContentValues;
+import android.content.res.Resources;
+import android.widget.AutoCompleteTextView;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.text.SpannableStringBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.openimis.imisclaims.tools.StorageManager;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+@RunWith(RobolectricTestRunner.class)
+public class ClaimActivityTest {
+    @Mock
+    Global global;
+    
+    @Mock
+    SQLHandler sqlHandler;
+    
+    @Mock
+    Activity activity;
+    
+    @Mock
+    Resources resources;
+    
+    @Mock
+    StorageManager storageManager;
+    
+    ClaimActivity claimActivity;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(activity.getResources()).thenReturn(resources);
+        when(resources.getString(anyInt())).thenReturn("mockString");
+        claimActivity = Robolectric.buildActivity(ClaimActivity.class).create().start().resume().visible().get();
+        claimActivity.sqlHandler = sqlHandler;
+        claimActivity.global = global;
+        when(global.isNetworkAvailable()).thenReturn(true); // or false, it doesn't matter
+    }
+
+    @Test
+    public void testSaveClaim_ShouldInsertInDatabase() {
+        EditText etHF = mock(EditText.class);
+        EditText etClaimAdmin = mock(EditText.class);
+        EditText etClaimCode = mock(EditText.class);
+        EditText etGuaranteeNo = mock(EditText.class);
+        EditText etCHFID = mock(EditText.class);
+        EditText etStart = mock(EditText.class);
+        EditText etEnd = mock(EditText.class);
+
+        AutoCompleteTextView etDiagnosis = mock(AutoCompleteTextView.class);
+        AutoCompleteTextView etDiagnosis1 = mock(AutoCompleteTextView.class);
+        AutoCompleteTextView etDiagnosis2 = mock(AutoCompleteTextView.class);
+        AutoCompleteTextView etDiagnosis3 = mock(AutoCompleteTextView.class);
+        AutoCompleteTextView etDiagnosis4 = mock(AutoCompleteTextView.class);
+
+        when(etHF.getText()).thenReturn(new SpannableStringBuilder("HF001"));
+        when(etClaimAdmin.getText()).thenReturn(new SpannableStringBuilder("ADMIN001"));
+        when(etClaimCode.getText()).thenReturn(new SpannableStringBuilder("CLM001"));
+        when(etGuaranteeNo.getText()).thenReturn(new SpannableStringBuilder("GNT001"));
+        when(etCHFID.getText()).thenReturn(new SpannableStringBuilder("INS12345"));
+        when(etStart.getText()).thenReturn(new SpannableStringBuilder("2025-12-01"));
+        when(etEnd.getText()).thenReturn(new SpannableStringBuilder("2025-12-09"));
+        when(etDiagnosis.getText()).thenReturn(new SpannableStringBuilder("A01"));
+        when(etDiagnosis1.getText()).thenReturn(new SpannableStringBuilder("B01"));
+        when(etDiagnosis2.getText()).thenReturn(new SpannableStringBuilder("C01"));
+        when(etDiagnosis3.getText()).thenReturn(new SpannableStringBuilder("D01"));
+        when(etDiagnosis4.getText()).thenReturn(new SpannableStringBuilder("E01"));
+
+        AutoCompleteTextView etVisitType = mock(AutoCompleteTextView.class);
+        AutoCompleteTextView patientCondition = mock(AutoCompleteTextView.class);
+        when(etVisitType.getTag()).thenReturn("O");
+        when(patientCondition.getTag()).thenReturn("A");
+
+        CheckBox etPreAuth = mock(CheckBox.class);
+        when(etPreAuth.isChecked()).thenReturn(false);
+
+        claimActivity.etHealthFacility = etHF;
+        claimActivity.etClaimAdmin = etClaimAdmin;
+        claimActivity.etClaimCode = etClaimCode;
+        claimActivity.etGuaranteeNo = etGuaranteeNo;
+        claimActivity.etInsureeNumber = etCHFID;
+        claimActivity.etStartDate = etStart;
+        claimActivity.etEndDate = etEnd;
+
+        claimActivity.etDiagnosis = etDiagnosis;
+        claimActivity.etDiagnosis1 = etDiagnosis1;
+        claimActivity.etDiagnosis2 = etDiagnosis2;
+        claimActivity.etDiagnosis3 = etDiagnosis3;
+        claimActivity.etDiagnosis4 = etDiagnosis4;
+
+        claimActivity.etVisitType = etVisitType;
+        claimActivity.etPatientCondition = patientCondition;
+        claimActivity.etPreAuthorization = etPreAuth;
+
+        ArrayList<HashMap<String, String>> fakeItems = new ArrayList<>();
+        HashMap<String, String> item1 = new HashMap<>();
+        item1.put("Code", "ITEM001");
+        item1.put("Price", "50");
+        item1.put("Quantity", "1");
+        fakeItems.add(item1);
+        claimActivity.lvItemList = fakeItems;
+
+        ArrayList<HashMap<String, String>> fakeServices = new ArrayList<>();
+        HashMap<String, String> svc1 = new HashMap<>();
+        svc1.put("Code", "SVC001");
+        svc1.put("Price", "40");
+        svc1.put("Quantity", "1");
+        svc1.put("PackageType", "P");
+        svc1.put("SubServicesItems", "[]");
+        fakeServices.add(svc1);
+        claimActivity.lvServiceList = fakeServices;
+
+        doNothing().when(sqlHandler).saveClaim(any(ContentValues.class), anyList(), anyList());
+
+        boolean result = claimActivity.saveClaim();
+
+        assertTrue(result);
+        verify(sqlHandler, times(1))
+                .saveClaim(any(ContentValues.class), anyList(), anyList());
+    }
+
+}

--- a/claimManagement/src/test/java/org/openimis/imisclaims/ClaimManagementActivityTest.java
+++ b/claimManagement/src/test/java/org/openimis/imisclaims/ClaimManagementActivityTest.java
@@ -1,7 +1,0 @@
-package org.openimis.imisclaims;
-
-import junit.framework.TestCase;
-
-public class ClaimManagementActivityTest extends TestCase {
-
-}


### PR DESCRIPTION
# Description
Here I've implemented a basic test for the `saveClaim` method of the `ClaimActivity.java` class. We used Robolectric to simulate an Android environment and access the application context, which allowed us to test an Android Activity, albeit within certain limitations.
We Implemented this Test in ClaimActivityTest class.

# Type of change
Chore(CI/CD)

# CheckLists
Unit Tests added : 
testSaveClaim_ShouldInsertInDatabase – PASSED ✅

Similarly, for the Policies app, we had to change certain attributes or methods from private to protected to be able to mock them with Mockito.
