### PR TITLE
refactor(claims): rename RAR terminology to ZIP across app

### DIFF
--- a/claimManagement/build.gradle
+++ b/claimManagement/build.gradle
@@ -59,7 +59,7 @@ android {
         resValue "string", "ReleaseDateValue", getDate()
         buildConfigField "String", "API_BASE_URL", '"http://demo.openimis.org/"'
         buildConfigField "String", "REST_API_PREFIX", '"rest"'
-        buildConfigField "String", "RAR_PASSWORD", '")(#$1HsD"'
+        buildConfigField "String", "ZIP_PASSWORD", '")(#$1HsD"'
         buildConfigField "String", "API_VERSION", '"3"'
         resValue "string", "release_tag", "release/25.04"
         resValue "string", "sentry_dsn", ""

--- a/claimManagement/custom-flavours.gradle.dist
+++ b/claimManagement/custom-flavours.gradle.dist
@@ -6,7 +6,7 @@ android {
             buildConfigField "String", "API_BASE_URL", [API_BASE_URL]
             buildConfigField "String", "APP_DIR", [APP_DIR_NAME]
             buildConfigField "String", "API_VERSION", [API_VERSION]
-            buildConfigField "String", "RAR_PASSWORD", [RAR_PASSWORD]
+            buildConfigField "String", "ZIP_PASSWORD", [ZIP_PASSWORD]
             resValue "string", "app_name_claims", [APP_NAME]
         }
     }

--- a/claimManagement/src/bepha/res/values/strings.xml
+++ b/claimManagement/src/bepha/res/values/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="settings">Settings</string>
-  <string name="RarPassword">RAR Password</string>
-  <string name="DefaultRarPassword">Set the default RAR password</string>
-  <string name="SaveRarPassword">Save</string>
+  <string name="ZipPassword">ZIP Password</string>
+  <string name="DefaultZipPassword">Set the default ZIP password</string>
+  <string name="SaveZipPassword">Save</string>
   <string name="InsuranceNumber">Insuree number</string>
   <string name="ErrorOccurred">Error occurred while processing data</string>
   <string name="SomethingWrongServer">Something went wrong on the server.</string>

--- a/claimManagement/src/chf/res/values-sw/strings.xml
+++ b/claimManagement/src/chf/res/values-sw/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="settings">Mipangilio</string>
-  <string name="RarPassword">Nenosiri la RAR</string>
-  <string name="DefaultRarPassword">Weka nambari ya default ya RAR</string>
-  <string name="SaveRarPassword">Hifadhi</string>
+  <string name="ZipPassword">Nenosiri la ZIP</string>
+  <string name="DefaultZipPassword">Weka nambari ya default ya ZIP</string>
+  <string name="SaveZipPassword">Hifadhi</string>
   <string name="InsuranceNumber">CHFID</string>
   <string name="ErrorOccurred">Tatizo limetokea wakati wa kuchakata taarifa.</string>
   <string name="SomethingWrongServer">Kuna kitu hakijakaa sawa kwenye kompuyta kuu.</string>

--- a/claimManagement/src/chf/res/values/strings.xml
+++ b/claimManagement/src/chf/res/values/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="settings">Settings</string>
-  <string name="RarPassword">RAR Password</string>
-  <string name="DefaultRarPassword">Set the default RAR password</string>
-  <string name="SaveRarPassword">Save</string>
+  <string name="ZipPassword">ZIP Password</string>
+  <string name="DefaultZipPassword">Set the default ZIP password</string>
+  <string name="SaveZipPassword">Save</string>
   <string name="InsuranceNumber">CHF number</string>
   <string name="ErrorOccurred">Error occurred while processing data</string>
   <string name="SomethingWrongServer">Something went wrong on the server.</string>

--- a/claimManagement/src/main/java/org/openimis/imisclaims/AppInformation.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/AppInformation.java
@@ -4,7 +4,7 @@ import java.text.SimpleDateFormat;
 import java.util.Locale;
 
 import static org.openimis.imisclaims.BuildConfig.API_BASE_URL;
-import static org.openimis.imisclaims.BuildConfig.RAR_PASSWORD;
+import static org.openimis.imisclaims.BuildConfig.ZIP_PASSWORD;
 import static org.openimis.imisclaims.BuildConfig.API_VERSION;
 
 public final class AppInformation {
@@ -13,8 +13,8 @@ public final class AppInformation {
             return API_BASE_URL;
         }
 
-        public static String getDefaultRarPassword() {
-            return RAR_PASSWORD;
+        public static String getDefaultZipPassword() {
+            return ZIP_PASSWORD;
         }
 
         public static String getApiVersion() {

--- a/claimManagement/src/main/java/org/openimis/imisclaims/Global.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/Global.java
@@ -57,7 +57,7 @@ import java.util.Map;
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 
-import static org.openimis.imisclaims.BuildConfig.RAR_PASSWORD;
+import static org.openimis.imisclaims.BuildConfig.ZIP_PASSWORD;
 
 import org.openimis.imisclaims.tools.Log;
 
@@ -73,7 +73,7 @@ public class Global extends Application {
     private int UserId;
     private String AppDirectory;
     private final Map<String, String> SubDirectories = new HashMap<>();
-    private static final String _DefaultRarPassword = RAR_PASSWORD;
+    private static final String _DefaultZipPassword = ZIP_PASSWORD;
     private Token JWTToken;
     private String[] permissions;
 
@@ -101,8 +101,8 @@ public class Global extends Application {
         return instance.getApplicationContext();
     }
 
-    public String getDefaultRarPassword() {
-        return _DefaultRarPassword;
+    public String getDefaultZipPassword() {
+        return _DefaultZipPassword;
     }
 
     public String getOfficerCode() {
@@ -288,18 +288,18 @@ public class Global extends Application {
         return Environment.getExternalStorageState();
     }
 
-    public String getRarPwd() {
+    public String getZipPwd() {
         String password = "";
         SharedPreferences sharedPreferences = getDefaultSharedPreferences();
-        if (!sharedPreferences.contains("rarPwd")) {
-            password = getDefaultRarPassword();
+        if (!sharedPreferences.contains("zipPwd")) {
+            password = getDefaultZipPassword();
         } else {
-            String encryptedRarPassword = sharedPreferences.getString("rarPwd", getDefaultRarPassword());
-            String trimEncryptedPassword = encryptedRarPassword.trim();
+            String encryptedZipPassword = sharedPreferences.getString("zipPwd", getDefaultZipPassword());
+            String trimEncryptedPassword = encryptedZipPassword.trim();
             String salt = sharedPreferences.getString("salt", null);
             String trimSalt = salt.trim();
             try {
-                password = decryptRarPwd(trimEncryptedPassword, trimSalt);
+                password = decryptZipPwd(trimEncryptedPassword, trimSalt);
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -307,7 +307,7 @@ public class Global extends Application {
         return password;
     }
 
-    private String decryptRarPwd(String dataToDecrypt, String decPassword) throws Exception {
+    private String decryptZipPwd(String dataToDecrypt, String decPassword) throws Exception {
         SecretKeySpec key = generateKey(decPassword);
         Cipher c = Cipher.getInstance("AES");
         c.init(Cipher.DECRYPT_MODE, key);

--- a/claimManagement/src/main/java/org/openimis/imisclaims/SettingsActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/SettingsActivity.java
@@ -16,8 +16,8 @@ import javax.crypto.spec.SecretKeySpec;
 
 public class SettingsActivity extends ImisActivity {
 
-    Button btnSaveRarPwd, btnDefaultRarPassword;
-    EditText etRarPassword;
+    Button btnSaveZipPwd, btnDefaultZipPassword;
+    EditText etZipPassword;
     private String salt, password;
     public static String generatedSalt;
     Global global;
@@ -29,27 +29,27 @@ public class SettingsActivity extends ImisActivity {
 
         actionBar.setTitle("Settings");
 
-        btnSaveRarPwd = (Button)findViewById(R.id.btnSaveRarPwd);
-        etRarPassword = (EditText)findViewById(R.id.rarPassword);
-        btnDefaultRarPassword = (Button) findViewById(R.id.btnDefaultRarPassword);
+        btnSaveZipPwd = (Button)findViewById(R.id.btnSaveZipPwd);
+        etZipPassword = (EditText)findViewById(R.id.zipPassword);
+        btnDefaultZipPassword = (Button) findViewById(R.id.btnDefaultZipPassword);
 
-        btnSaveRarPwd.setOnClickListener(view -> {
-            if(etRarPassword.getText().length() == 0){
-               ShowDialog("Rar password required");
+        btnSaveZipPwd.setOnClickListener(view -> {
+            if(etZipPassword.getText().length() == 0){
+               ShowDialog("Zip password required");
             }
             else {
-                password = etRarPassword.getText().toString();
-                saveRarPassword(password);
+                password = etZipPassword.getText().toString();
+                saveZipPassword(password);
                 ShowDialog("Password has been changed");
-                etRarPassword.setText("");
+                etZipPassword.setText("");
             }
 
         });
 
-        btnDefaultRarPassword.setOnClickListener(view -> {
-            password = global.getDefaultRarPassword();
-            saveRarPassword(password);
-            ShowDialog("Password has been changed to the default rar password");
+        btnDefaultZipPassword.setOnClickListener(view -> {
+            password = global.getDefaultZipPassword();
+            saveZipPassword(password);
+            ShowDialog("Password has been changed to the default zip password");
         });
 
     }
@@ -67,7 +67,7 @@ public class SettingsActivity extends ImisActivity {
         return secretKeySpec;
     }
 
-    public String encryptRarPwd(String dataToEncrypt, String encPassword) throws Exception{
+    public String encryptZipPwd(String dataToEncrypt, String encPassword) throws Exception{
         SecretKeySpec key = generateKey(encPassword);
         Cipher c = Cipher.getInstance("AES");
         c.init(Cipher.ENCRYPT_MODE, key);
@@ -76,7 +76,7 @@ public class SettingsActivity extends ImisActivity {
         return encryptedValue;
     }
 
-    public String decryptRarPwd(String dataToDecrypt, String decPassword) throws Exception {
+    public String decryptZipPwd(String dataToDecrypt, String decPassword) throws Exception {
         SecretKeySpec key = generateKey(decPassword);
         Cipher c = Cipher.getInstance("AES");
         c.init(Cipher.DECRYPT_MODE, key);
@@ -96,15 +96,15 @@ public class SettingsActivity extends ImisActivity {
         return encodedSalt;
     }
 
-    public void saveRarPassword(String password){
+    public void saveZipPassword(String password){
         try {
             SharedPreferences sharedPreferences = global.getDefaultSharedPreferences();
             SharedPreferences.Editor editor = sharedPreferences.edit();
             salt = generateSalt();
             String trimSalt = salt.trim();
-            String encryptedPassword = encryptRarPwd(password, trimSalt);
+            String encryptedPassword = encryptZipPwd(password, trimSalt);
             String trimEncryptedPassword = encryptedPassword.trim();
-            editor.putString("rarPwd", trimEncryptedPassword);
+            editor.putString("zipPwd", trimEncryptedPassword);
             editor.putString("salt", trimSalt);
             editor.apply();
         }

--- a/claimManagement/src/main/java/org/openimis/imisclaims/SynchronizeService.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/SynchronizeService.java
@@ -256,7 +256,7 @@ public class SynchronizeService extends JobIntentService {
         String zipFilename = "Claims" + "_" + global.getOfficerCode() + "_" + d + ".zip";
         File zipFile = storageManager.createTempFile("exports/claim/" + zipFilename, true);
 
-        String password = global.getRarPwd();
+        String password = global.getZipPwd();
         ZipUtils.zipFiles(exportedClaims, zipFile, password);
         FileUtils.deleteFiles(exportedClaims.toArray(new File[0]));
 

--- a/claimManagement/src/main/res/layout/settings.xml
+++ b/claimManagement/src/main/res/layout/settings.xml
@@ -12,10 +12,10 @@
         android:textColor="@color/Black"
         android:layout_marginLeft="10dp"
         android:layout_marginTop="10dp"
-        android:text="@string/RarPassword" />
+        android:text="@string/ZipPassword" />
 
     <EditText
-        android:id="@+id/rarPassword"
+        android:id="@+id/zipPassword"
         android:layout_width="match_parent"
         android:layout_height="50dp"
         android:paddingLeft="10dp"
@@ -24,17 +24,17 @@
         android:inputType="textPassword">
     </EditText>
 
-    <LinearLayout android:id="@+id/llSaveRarButton"
+    <LinearLayout android:id="@+id/llSaveZipButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal">
 
         <Button
-        android:id="@+id/btnSaveRarPwd"
+        android:id="@+id/btnSaveZipPwd"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:text="@string/SaveRarPassword"
+        android:text="@string/SaveZipPassword"
         android:layout_marginBottom="10dp"/>
     </LinearLayout>
 
@@ -46,19 +46,19 @@
         android:textColor="@color/Black"
         android:layout_marginLeft="10dp"
         android:layout_marginTop="10dp"
-        android:text="@string/DefaultRarPassword" />
+        android:text="@string/DefaultZipPassword" />
 
-    <LinearLayout android:id="@+id/llDefaultRarPassword"
+    <LinearLayout android:id="@+id/llDefaultZipPassword"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal">
 
         <Button
-            android:id="@+id/btnDefaultRarPassword"
+            android:id="@+id/btnDefaultZipPassword"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="@string/SaveRarPassword" />
+            android:text="@string/SaveZipPassword" />
     </LinearLayout>
 
 </LinearLayout>

--- a/claimManagement/src/main/res/values-fr/strings.xml
+++ b/claimManagement/src/main/res/values-fr/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="settings">Réglages</string>
-  <string name="RarPassword">Mot de passe RAR</string>
-  <string name="DefaultRarPassword">Définir le mot de passe RAR par défaut</string>
-  <string name="SaveRarPassword">Sauvegarder</string>
+  <string name="ZipPassword">Mot de passe ZIP</string>
+  <string name="DefaultZipPassword">Définir le mot de passe ZIP par défaut</string>
+  <string name="SaveZipPassword">Sauvegarder</string>
   <string name="InsuranceNumber">Numéro d\'assurance</string>
   <string name="ErrorOccurred">Une erreur s\'est produite lors du traitement des données.</string>
   <string name="SomethingWrongServer">Il y a eu un problème sur le serveur.</string>

--- a/claimManagement/src/main/res/values-sw/strings.xml
+++ b/claimManagement/src/main/res/values-sw/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="settings">Mipangilio</string>
-  <string name="RarPassword">Nenosiri la RAR</string>
-  <string name="DefaultRarPassword">Weka nambari ya default ya RAR</string>
-  <string name="SaveRarPassword">Hifadhi</string>
+  <string name="ZipPassword">Nenosiri la ZIP</string>
+  <string name="DefaultZipPassword">Weka nambari ya default ya ZIP</string>
+  <string name="SaveZipPassword">Hifadhi</string>
   <string name="InsuranceNumber">CHFID</string>
   <string name="ErrorOccurred">Tatizo limetokea wakati wa kuchakata taarifa.</string>
   <string name="SomethingWrongServer">Kuna kitu hakijakaa sawa kwenye kompuyta kuu.</string>

--- a/claimManagement/src/main/res/values/strings.xml
+++ b/claimManagement/src/main/res/values/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
     <string name="settings">Settings</string>
-    <string name="RarPassword">RAR Password</string>
-    <string name="DefaultRarPassword">Set the default RAR password</string>
-    <string name="SaveRarPassword">Save</string>
+    <string name="ZipPassword">ZIP Password</string>
+    <string name="DefaultZipPassword">Set the default ZIP password</string>
+    <string name="SaveZipPassword">Save</string>
     <string name="InsuranceNumber">Insuree number</string>
     <string name="ErrorOccurred">Error occurred while processing data</string>
     <string name="SomethingWrongServer">Something went wrong on the server.</string>


### PR DESCRIPTION
# Description

- rename BuildConfig key RAR_PASSWORD to ZIP_PASSWORD

- update password APIs/fields and SharedPreferences key to zip naming

- update settings layout ids and localized string resources

- keep export behavior on ZIP (zip4j/.zip) while aligning wording

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="432" height="991" alt="image" src="https://github.com/user-attachments/assets/15949ac9-8ca2-47f0-8693-9629b7f5e123" />
<img width="432" height="934" alt="image" src="https://github.com/user-attachments/assets/578172b6-05d5-4832-aa58-49849fc83eed" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
