### PR TITLE
Fix Settings NPE and add RAR password visibility toggle

### DIFF
--- a/claimManagement/src/main/java/org/openimis/imisclaims/SettingsActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/SettingsActivity.java
@@ -20,7 +20,6 @@ public class SettingsActivity extends ImisActivity {
     EditText etRarPassword;
     private String salt, password;
     public static String generatedSalt;
-    Global global;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/claimManagement/src/main/res/layout/settings.xml
+++ b/claimManagement/src/main/res/layout/settings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -14,15 +15,20 @@
         android:layout_marginTop="10dp"
         android:text="@string/RarPassword" />
 
-    <EditText
-        android:id="@+id/rarPassword"
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
-        android:layout_height="50dp"
-        android:paddingLeft="10dp"
+        android:layout_height="wrap_content"
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"
-        android:inputType="textPassword">
-    </EditText>
+        app:endIconMode="password_toggle">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/rarPassword"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:paddingLeft="10dp"
+            android:inputType="textPassword|textNoSuggestions" />
+    </com.google.android.material.textfield.TextInputLayout>
 
     <LinearLayout android:id="@+id/llSaveRarButton"
         android:layout_width="match_parent"


### PR DESCRIPTION
# Description

Fix NPE when clicking on "save default rar_password" in settings page and add toggle visibility on password field

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [x] Enhancements

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="452" height="999" alt="Capture d’écran du 2026-04-16 18-31-26" src="https://github.com/user-attachments/assets/cfe1b764-0d6c-46f9-9bc9-1fe19f74b625" />
<img width="452" height="999" alt="Capture d’écran du 2026-04-16 18-31-32" src="https://github.com/user-attachments/assets/836bd1c1-c5d8-415c-85ec-237ce1eac2b9" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
