### PR TITLE
skip server error when fetching diagn.serv.items

### DIFF
--- a/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
@@ -688,7 +688,18 @@ public class MainActivity extends ImisActivity {
 
                         runOnUiThread(() -> {
                             progressDialog.dismiss();
-                            if (officerCode != null) {
+                            if (!fetchDiagnosesServicesItems.getSkippedMedicationPages().isEmpty()) {
+                                final String errorLogMessage = "Master data synced with partial medications.\nSkipped pages: "
+                                        + fetchDiagnosesServicesItems.getSkippedMedicationPages();
+                                showDialog(
+                                        errorLogMessage,
+                                        (dialog, which) -> {
+                                            if (officerCode != null) {
+                                                DownLoadServicesItemsPriceList(officerCode);
+                                            }
+                                        }
+                                );
+                            } else if (officerCode != null) {
                                 DownLoadServicesItemsPriceList(officerCode);
                             }
                         });

--- a/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
@@ -619,7 +619,8 @@ public class MainActivity extends ImisActivity {
             Thread thread = new Thread() {
                 public void run() {
                     try {
-                        DiagnosesServicesMedications diagnosesServicesMedications = new FetchDiagnosesServicesItems().execute();
+                        FetchDiagnosesServicesItems fetchDiagnosesServicesItems = new FetchDiagnosesServicesItems();
+                        DiagnosesServicesMedications diagnosesServicesMedications = fetchDiagnosesServicesItems.execute();
                         saveLastUpdateDate(diagnosesServicesMedications.getLastUpdated());
                         sqlHandler.ClearAll("tblReferences");
                         sqlHandler.ClearAll("tblHealthFacilities");
@@ -688,20 +689,7 @@ public class MainActivity extends ImisActivity {
 
                         runOnUiThread(() -> {
                             progressDialog.dismiss();
-                            if (!fetchDiagnosesServicesItems.getSkippedMedicationPages().isEmpty()) {
-                                final String errorLogMessage = "Master data synced with partial medications.\nSkipped pages: "
-                                        + fetchDiagnosesServicesItems.getSkippedMedicationPages();
-                                showDialog(
-                                        errorLogMessage,
-                                        (dialog, which) -> {
-                                            if (officerCode != null) {
-                                                DownLoadServicesItemsPriceList(officerCode);
-                                            }
-                                        }
-                                );
-                            } else if (officerCode != null) {
-                                DownLoadServicesItemsPriceList(officerCode);
-                            }
+                            handlePostMasterDataSync(officerCode, fetchDiagnosesServicesItems.getSkippedMedicationPages());
                         });
                     } catch (Exception e) {
                         e.printStackTrace();
@@ -724,7 +712,27 @@ public class MainActivity extends ImisActivity {
         }
     }
 
-    private void DownLoadServicesItemsPriceList(@NonNull final String claimAdministratorCode) {
+    void handlePostMasterDataSync(
+            @Nullable String officerCode,
+            @NonNull List<Integer> skippedMedicationPages
+    ) {
+        if (!skippedMedicationPages.isEmpty()) {
+            final String errorLogMessage = "Master data synced with partial medications.\nSkipped pages: "
+                    + skippedMedicationPages;
+            showDialog(
+                    errorLogMessage,
+                    (dialog, which) -> {
+                        if (officerCode != null) {
+                            DownLoadServicesItemsPriceList(officerCode);
+                        }
+                    }
+            );
+        } else if (officerCode != null) {
+            DownLoadServicesItemsPriceList(officerCode);
+        }
+    }
+
+    protected void DownLoadServicesItemsPriceList(@NonNull final String claimAdministratorCode) {
         if (global.isNetworkAvailable()) {
             String progress_message = getResources().getString(R.string.Services) + ", " + getResources().getString(R.string.Items) + "...";
             progressDialog = ProgressDialog.show(this, getResources().getString(R.string.mapping), progress_message);

--- a/claimManagement/src/main/java/org/openimis/imisclaims/network/util/PaginatedResponseUtils.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/network/util/PaginatedResponseUtils.java
@@ -4,14 +4,18 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
+import org.openimis.imisclaims.network.exception.HttpException;
 import org.openimis.imisclaims.network.request.BaseFHIRGetPaginatedRequest;
 import org.openimis.imisclaims.network.response.PaginatedResponse;
+import org.openimis.imisclaims.tools.Log;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class PaginatedResponseUtils {
+    private static final String LOG_TAG = "FHIR_SYNC_TOLERANCE";
 
     private PaginatedResponseUtils() {
         throw new IllegalAccessError("This constructor is private");
@@ -50,10 +54,154 @@ public class PaginatedResponseUtils {
         return list;
     }
 
+    @NonNull
+    @WorkerThread
+    public static <T, U> DownloadResult<U> downloadAllSkipFailedPages(
+            @NonNull String endpoint,
+            @NonNull RequestExecutor<T> executor,
+            @Nullable Mapper.Transformer<T, U> transformer,
+            int maxPages,
+            int maxConsecutiveFailures
+    ) throws Exception {
+        int page = 0;
+        int consecutiveFailures = 0;
+        boolean hasMore = true;
+        boolean hasSkippedPages = false;
+        List<U> list = new ArrayList<>();
+        List<Integer> skippedPages = new ArrayList<>();
+        List<Integer> recoveredPages = new ArrayList<>();
+        Mapper<T, U> mapper = transformer != null ? new Mapper<>(transformer) : null;
+
+        while (hasMore && page < maxPages) {
+            final int displayPage = page + 1;
+            try {
+                PaginatedResponse<T> response = executor.download(page);
+                if (mapper != null) {
+                    list.addAll(mapper.map(response.getValue()));
+                } else {
+                    list.addAll((Collection<? extends U>) response.getValue());
+                }
+                hasMore = response.hasMore();
+                consecutiveFailures = 0;
+                if (hasSkippedPages) {
+                    recoveredPages.add(displayPage);
+                }
+            } catch (Exception exception) {
+                skippedPages.add(displayPage);
+                hasSkippedPages = true;
+                consecutiveFailures++;
+                logSkippedPage(endpoint, displayPage, exception);
+                if (consecutiveFailures >= maxConsecutiveFailures) {
+                    Log.w(
+                            LOG_TAG,
+                            String.format(
+                                    "endpoint=%s action=stop reason=maxConsecutiveFailures reached skippedPages=%s",
+                                    endpoint,
+                                    skippedPages
+                            )
+                    );
+                    break;
+                }
+            }
+            page++;
+        }
+
+        if (page >= maxPages && hasMore) {
+            Log.w(
+                    LOG_TAG,
+                    String.format(
+                            "endpoint=%s action=stop reason=maxPages reached maxPages=%s skippedPages=%s",
+                            endpoint,
+                            maxPages,
+                            skippedPages
+                    )
+            );
+        }
+
+        Log.i(
+                LOG_TAG,
+                String.format(
+                        "endpoint=%s summary skippedPages=%s recoveredPages=%s totalItems=%s",
+                        endpoint,
+                        skippedPages,
+                        recoveredPages,
+                        list.size()
+                )
+        );
+        return new DownloadResult<>(list, skippedPages, recoveredPages);
+    }
+
+    private static void logSkippedPage(@NonNull String endpoint, int page, @NonNull Exception exception) {
+        String errorType = exception.getClass().getSimpleName();
+        if (exception instanceof HttpException) {
+            HttpException httpException = (HttpException) exception;
+            Log.w(
+                    LOG_TAG,
+                    String.format(
+                            "endpoint=%s page=%s action=skip errorType=%s code=%s message=%s",
+                            endpoint,
+                            page,
+                            errorType,
+                            httpException.getCode(),
+                            exception.getMessage()
+                    )
+            );
+        } else {
+            Log.w(
+                    LOG_TAG,
+                    String.format(
+                            "endpoint=%s page=%s action=skip errorType=%s message=%s",
+                            endpoint,
+                            page,
+                            errorType,
+                            exception.getMessage()
+                    )
+            );
+        }
+    }
+
     public interface RequestExecutor<T> {
 
         @NonNull
         @WorkerThread
         PaginatedResponse<T> download(int page) throws Exception;
+    }
+
+    public static class DownloadResult<U> {
+        @NonNull
+        private final List<U> items;
+        @NonNull
+        private final List<Integer> skippedPages;
+        @NonNull
+        private final List<Integer> recoveredPages;
+
+        public DownloadResult(
+                @NonNull List<U> items,
+                @NonNull List<Integer> skippedPages,
+                @NonNull List<Integer> recoveredPages
+        ) {
+            this.items = items;
+            this.skippedPages = skippedPages;
+            this.recoveredPages = recoveredPages;
+        }
+
+        @NonNull
+        public List<U> getItems() {
+            return items;
+        }
+
+        @NonNull
+        public List<Integer> getSkippedPages() {
+            return Collections.unmodifiableList(skippedPages);
+        }
+
+        @NonNull
+        public List<Integer> getRecoveredPages() {
+            return Collections.unmodifiableList(recoveredPages);
+        }
+
+        public boolean hasSkippedPages() {
+            return !skippedPages.isEmpty();
+        }
     }
 }

--- a/claimManagement/src/main/java/org/openimis/imisclaims/usecase/FetchDiagnosesServicesItems.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/usecase/FetchDiagnosesServicesItems.java
@@ -19,8 +19,11 @@ import org.openimis.imisclaims.network.util.PaginatedResponseUtils;
 import org.openimis.imisclaims.util.DateUtils;
 
 import java.util.Date;
+import java.util.List;
 
 public class FetchDiagnosesServicesItems {
+    private static final int MAX_PAGES = 1000;
+    private static final int MAX_CONSECUTIVE_FAILURES = 3;
 
     @NonNull
     private final GetActivityDefinitionsRequest getActivityDefinitionsRequest;
@@ -28,6 +31,8 @@ public class FetchDiagnosesServicesItems {
     private final GetDiagnosesRequest getDiagnosesRequest;
     @NonNull
     private final GetMedicationsRequest getMedicationsRequest;
+    @NonNull
+    private List<Integer> skippedMedicationPages = java.util.Collections.emptyList();
 
     public FetchDiagnosesServicesItems() {
         this(
@@ -50,6 +55,16 @@ public class FetchDiagnosesServicesItems {
     @NonNull
     @WorkerThread
     public DiagnosesServicesMedications execute() throws Exception {
+        PaginatedResponseUtils.DownloadResult<Medication> medicationDownloadResult =
+                PaginatedResponseUtils.downloadAllSkipFailedPages(
+                        "Medication",
+                        getMedicationsRequest::get,
+                        this::toMedication,
+                        MAX_PAGES,
+                        MAX_CONSECUTIVE_FAILURES
+                );
+        skippedMedicationPages = medicationDownloadResult.getSkippedPages();
+
         // previous code was passing sometimes a `last_updated_date` but it was either empty or
         // `new Date(0)`. I'm still returning the last updated date in case it's one day used
         // again.¯\_(ツ)_/¯
@@ -60,11 +75,13 @@ public class FetchDiagnosesServicesItems {
                 getActivityDefinitionsRequest::get,
                 this::toService
         ),
-                /* medications = */ PaginatedResponseUtils.downloadAll(
-                getMedicationsRequest::get,
-                this::toMedication
-        )
+                /* medications = */ medicationDownloadResult.getItems()
         );
+    }
+
+    @NonNull
+    public List<Integer> getSkippedMedicationPages() {
+        return skippedMedicationPages;
     }
 
     @NonNull

--- a/claimManagement/src/test/java/org/openimis/imisclaims/MainActivityPostSyncTest.java
+++ b/claimManagement/src/test/java/org/openimis/imisclaims/MainActivityPostSyncTest.java
@@ -1,0 +1,84 @@
+package org.openimis.imisclaims;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+public class MainActivityPostSyncTest {
+
+    private TestMainActivity activity;
+
+    @Before
+    public void setup() {
+        activity = new TestMainActivity();
+    }
+
+    @Test
+    public void downloadAllData_showsPartialMedicationDialog_whenSkippedMedicationPagesNotEmpty() {
+        activity.handlePostMasterDataSync("OFFICER", Arrays.asList(2, 4));
+
+        assertTrue(activity.dialogShown);
+        assertNotNull(activity.lastDialogMessage);
+        assertTrue(activity.lastDialogMessage.contains("partial medications"));
+        assertTrue(activity.lastDialogMessage.contains("[2, 4]"));
+    }
+
+    @Test
+    public void downloadAllData_doesNotAutoCallDownloadPriceList_beforeDialogConfirmation_whenSkippedPagesExist() {
+        activity.handlePostMasterDataSync("OFFICER", Collections.singletonList(2));
+
+        assertTrue(activity.dialogShown);
+        assertFalse(activity.downloadCalled);
+    }
+
+    @Test
+    public void downloadAllData_callsDownloadPriceListDirectly_whenNoSkippedPages_andOfficerCodePresent() {
+        activity.handlePostMasterDataSync("OFFICER", Collections.emptyList());
+
+        assertTrue(activity.downloadCalled);
+        assertEquals("OFFICER", activity.downloadCalledWith);
+        assertFalse(activity.dialogShown);
+    }
+
+    @Test
+    public void downloadAllData_afterDialogConfirmation_callsDownloadPriceList_whenOfficerCodePresent() {
+        activity.handlePostMasterDataSync("OFFICER", Collections.singletonList(3));
+
+        assertFalse(activity.downloadCalled);
+        activity.lastOkCallback.onClick(null, 0);
+
+        assertTrue(activity.downloadCalled);
+        assertEquals("OFFICER", activity.downloadCalledWith);
+    }
+
+    public static class TestMainActivity extends MainActivity {
+        boolean dialogShown = false;
+        boolean downloadCalled = false;
+        String downloadCalledWith;
+        String lastDialogMessage;
+        DialogInterface.OnClickListener lastOkCallback;
+
+        @Override
+        protected AlertDialog showDialog(String msg, DialogInterface.OnClickListener okCallback) {
+            this.dialogShown = true;
+            this.lastDialogMessage = msg;
+            this.lastOkCallback = okCallback;
+            return null;
+        }
+
+        @Override
+        protected void DownLoadServicesItemsPriceList(String claimAdministratorCode) {
+            this.downloadCalled = true;
+            this.downloadCalledWith = claimAdministratorCode;
+        }
+    }
+}

--- a/claimManagement/src/test/java/org/openimis/imisclaims/network/util/PaginatedResponseUtilsTest.java
+++ b/claimManagement/src/test/java/org/openimis/imisclaims/network/util/PaginatedResponseUtilsTest.java
@@ -1,0 +1,142 @@
+package org.openimis.imisclaims.network.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.openimis.imisclaims.network.exception.HttpException;
+import org.openimis.imisclaims.network.response.PaginatedResponse;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PaginatedResponseUtilsTest {
+
+    @Test
+    public void downloadAllSkipFailedPages_returnsAllItems_whenNoFailure() throws Exception {
+        PaginatedResponseUtils.DownloadResult<String> result = PaginatedResponseUtils.downloadAllSkipFailedPages(
+                "Medication",
+                page -> {
+                    if (page == 0) {
+                        return new PaginatedResponse<>(Collections.singletonList("a"), true);
+                    }
+                    return new PaginatedResponse<>(Collections.singletonList("b"), false);
+                },
+                null,
+                100,
+                3
+        );
+
+        assertEquals(Arrays.asList("a", "b"), result.getItems());
+        assertTrue(result.getSkippedPages().isEmpty());
+        assertTrue(result.getRecoveredPages().isEmpty());
+        assertFalse(result.hasSkippedPages());
+    }
+
+    @Test
+    public void downloadAllSkipFailedPages_skipsSingleFailedPage_andContinues() throws Exception {
+        PaginatedResponseUtils.DownloadResult<String> result = PaginatedResponseUtils.downloadAllSkipFailedPages(
+                "Medication",
+                page -> {
+                    if (page == 0) {
+                        return new PaginatedResponse<>(Collections.singletonList("p1"), true);
+                    }
+                    if (page == 1) {
+                        throw new HttpException(500, "server", "error", null);
+                    }
+                    if (page == 2) {
+                        return new PaginatedResponse<>(Collections.singletonList("p3"), false);
+                    }
+                    return new PaginatedResponse<>(Collections.emptyList(), false);
+                },
+                null,
+                100,
+                3
+        );
+
+        assertEquals(Arrays.asList("p1", "p3"), result.getItems());
+        assertEquals(Collections.singletonList(2), result.getSkippedPages());
+        assertEquals(Collections.singletonList(3), result.getRecoveredPages());
+        assertTrue(result.hasSkippedPages());
+    }
+
+    @Test
+    public void downloadAllSkipFailedPages_stopsAfterMaxConsecutiveFailures() throws Exception {
+        Map<Integer, Exception> failures = new HashMap<>();
+        failures.put(0, new RuntimeException("f1"));
+        failures.put(1, new RuntimeException("f2"));
+        failures.put(2, new RuntimeException("f3"));
+
+        PaginatedResponseUtils.DownloadResult<String> result = PaginatedResponseUtils.downloadAllSkipFailedPages(
+                "Medication",
+                page -> {
+                    Exception failure = failures.get(page);
+                    if (failure != null) {
+                        throw failure;
+                    }
+                    return new PaginatedResponse<>(Collections.singletonList("ok"), false);
+                },
+                null,
+                100,
+                3
+        );
+
+        assertTrue(result.getItems().isEmpty());
+        assertEquals(Arrays.asList(1, 2, 3), result.getSkippedPages());
+        assertTrue(result.getRecoveredPages().isEmpty());
+    }
+
+    @Test
+    public void downloadAllSkipFailedPages_stopsAtMaxPages_whenHasMoreStillTrue() throws Exception {
+        PaginatedResponseUtils.DownloadResult<String> result = PaginatedResponseUtils.downloadAllSkipFailedPages(
+                "Medication",
+                page -> new PaginatedResponse<>(Collections.singletonList("i" + page), true),
+                null,
+                2,
+                3
+        );
+
+        assertEquals(Arrays.asList("i0", "i1"), result.getItems());
+        assertTrue(result.getSkippedPages().isEmpty());
+    }
+
+    @Test
+    public void downloadAllSkipFailedPages_recordsRecoveredPages_afterFailure() throws Exception {
+        PaginatedResponseUtils.DownloadResult<String> result = PaginatedResponseUtils.downloadAllSkipFailedPages(
+                "Medication",
+                page -> {
+                    if (page == 0) {
+                        throw new RuntimeException("fail");
+                    }
+                    if (page == 1) {
+                        return new PaginatedResponse<>(Collections.singletonList("r1"), true);
+                    }
+                    return new PaginatedResponse<>(Collections.singletonList("r2"), false);
+                },
+                null,
+                100,
+                3
+        );
+
+        assertEquals(Collections.singletonList(1), result.getSkippedPages());
+        assertEquals(Arrays.asList(2, 3), result.getRecoveredPages());
+        assertEquals(Arrays.asList("r1", "r2"), result.getItems());
+    }
+
+    @Test
+    public void downloadResult_listsAreUnmodifiable_forSkippedAndRecovered() {
+        PaginatedResponseUtils.DownloadResult<String> result =
+                new PaginatedResponseUtils.DownloadResult<>(
+                        Collections.singletonList("x"),
+                        Collections.singletonList(1),
+                        Collections.singletonList(2)
+                );
+
+        assertThrows(UnsupportedOperationException.class, () -> result.getSkippedPages().add(3));
+        assertThrows(UnsupportedOperationException.class, () -> result.getRecoveredPages().add(4));
+    }
+}

--- a/claimManagement/src/test/java/org/openimis/imisclaims/usecase/FetchDiagnosesServicesItemsTest.java
+++ b/claimManagement/src/test/java/org/openimis/imisclaims/usecase/FetchDiagnosesServicesItemsTest.java
@@ -1,0 +1,145 @@
+package org.openimis.imisclaims.usecase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openimis.imisclaims.domain.entity.DiagnosesServicesMedications;
+import org.openimis.imisclaims.network.dto.ActivityDefinitionDto;
+import org.openimis.imisclaims.network.dto.DiagnosisDto;
+import org.openimis.imisclaims.network.dto.IdentifierDto;
+import org.openimis.imisclaims.network.dto.MedicationDto;
+import org.openimis.imisclaims.network.request.GetActivityDefinitionsRequest;
+import org.openimis.imisclaims.network.request.GetDiagnosesRequest;
+import org.openimis.imisclaims.network.request.GetMedicationsRequest;
+import org.openimis.imisclaims.network.response.PaginatedResponse;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FetchDiagnosesServicesItemsTest {
+
+    @Mock
+    private GetActivityDefinitionsRequest getActivityDefinitionsRequest;
+    @Mock
+    private GetDiagnosesRequest getDiagnosesRequest;
+    @Mock
+    private GetMedicationsRequest getMedicationsRequest;
+
+    private FetchDiagnosesServicesItems useCase;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        useCase = new FetchDiagnosesServicesItems(
+                getActivityDefinitionsRequest,
+                getDiagnosesRequest,
+                getMedicationsRequest
+        );
+    }
+
+    @Test
+    public void execute_returnsDiagnosesServicesAndPartialMedications_whenMedicationPageFails() throws Exception {
+        when(getDiagnosesRequest.get()).thenReturn(Collections.singletonList(new DiagnosisDto("D1", "Diagnosis 1")));
+        when(getActivityDefinitionsRequest.get(anyInt())).thenReturn(new PaginatedResponse<>(
+                Collections.singletonList(new ActivityDefinitionDto(
+                        "s1",
+                        Collections.singletonList(new IdentifierDto("Code", "SVC1")),
+                        "Service1",
+                        "Service 1",
+                        10.0,
+                        "XAF",
+                        "active",
+                        new Date()
+                )),
+                false
+        ));
+
+        when(getMedicationsRequest.get(0)).thenReturn(new PaginatedResponse<>(Collections.singletonList(
+                new MedicationDto(
+                        "m1",
+                        Collections.singletonList(new IdentifierDto("Code", "MED1")),
+                        "Medication 1",
+                        20.0,
+                        "XAF",
+                        "active",
+                        1.0
+                )
+        ), true));
+        when(getMedicationsRequest.get(1)).thenThrow(new RuntimeException("server error"));
+        when(getMedicationsRequest.get(2)).thenReturn(new PaginatedResponse<>(Collections.singletonList(
+                new MedicationDto(
+                        "m2",
+                        Collections.singletonList(new IdentifierDto("Code", "MED2")),
+                        "Medication 2",
+                        30.0,
+                        "XAF",
+                        "active",
+                        1.0
+                )
+        ), false));
+
+        DiagnosesServicesMedications result = useCase.execute();
+
+        assertNotNull(result);
+        assertEquals(1, result.getDiagnoses().size());
+        assertEquals(1, result.getServices().size());
+        assertEquals(2, result.getMedications().size());
+        assertEquals(Collections.singletonList(2), useCase.getSkippedMedicationPages());
+    }
+
+    @Test
+    public void execute_exposesSkippedMedicationPages_afterPartialMedicationSync() throws Exception {
+        when(getDiagnosesRequest.get()).thenReturn(Collections.singletonList(new DiagnosisDto("D1", "Diagnosis 1")));
+        when(getActivityDefinitionsRequest.get(anyInt())).thenReturn(new PaginatedResponse<>(Collections.emptyList(), false));
+        when(getMedicationsRequest.get(0)).thenThrow(new RuntimeException("page 1 failed"));
+        when(getMedicationsRequest.get(1)).thenReturn(new PaginatedResponse<>(Collections.emptyList(), false));
+
+        useCase.execute();
+
+        assertEquals(Collections.singletonList(1), useCase.getSkippedMedicationPages());
+    }
+
+    @Test
+    public void execute_throws_whenDiagnosesRequestFails() throws Exception {
+        when(getDiagnosesRequest.get()).thenThrow(new RuntimeException("diagnoses down"));
+        when(getMedicationsRequest.get(anyInt())).thenReturn(new PaginatedResponse<>(Collections.emptyList(), false));
+
+        assertThrows(RuntimeException.class, () -> useCase.execute());
+    }
+
+    @Test
+    public void execute_throws_whenServicesRequestFails() throws Exception {
+        when(getDiagnosesRequest.get()).thenReturn(Collections.singletonList(new DiagnosisDto("D1", "Diagnosis 1")));
+        when(getActivityDefinitionsRequest.get(0)).thenThrow(new RuntimeException("services down"));
+        when(getMedicationsRequest.get(anyInt())).thenReturn(new PaginatedResponse<>(Collections.emptyList(), false));
+
+        assertThrows(RuntimeException.class, () -> useCase.execute());
+    }
+
+    @Test
+    public void getSkippedMedicationPages_emptyBeforeExecute_thenUpdatedAfterExecute() throws Exception {
+        assertTrue(useCase.getSkippedMedicationPages().isEmpty());
+
+        when(getDiagnosesRequest.get()).thenReturn(Collections.singletonList(new DiagnosisDto("D1", "Diagnosis 1")));
+        when(getActivityDefinitionsRequest.get(anyInt())).thenReturn(new PaginatedResponse<>(Collections.emptyList(), false));
+        when(getMedicationsRequest.get(0)).thenThrow(new RuntimeException("page 1 failed"));
+        when(getMedicationsRequest.get(1)).thenReturn(new PaginatedResponse<>(Collections.emptyList(), false));
+
+        useCase.execute();
+
+        assertEquals(Arrays.asList(1), useCase.getSkippedMedicationPages());
+    }
+}


### PR DESCRIPTION
# Description

During the download of items, services, and diagnostics, it frequently happens that some resources generate formatting errors (FHIR incompatibilities). These errors interrupt the ongoing data retrieval process and render the application unusable as is currently the case.

While formatting should normally be handled on the Django side, it is necessary, on the mobile side, to ensure that this type of situation does not compromise the overall functionality of the application.

Therefore, we have implemented a mechanism to skip problematic resources, ignoring them when they cannot be processed correctly. This prevents the process from blocking and ensures the continuity of the download and mapping of the remaining data.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [x] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1596" height="260" alt="500_http_error" src="https://github.com/user-attachments/assets/5024255a-deae-4d03-aa6d-e18a5484ae1f" />
<img width="449" height="993" alt="Capture d’écran du 2026-04-16 11-40-02" src="https://github.com/user-attachments/assets/5e127b35-0d65-4076-9d2a-48f333cda3ec" />
<img width="1745" height="536" alt="fetch_diag item serv_errors" src="https://github.com/user-attachments/assets/6719a3fc-dd16-4240-853a-25660ee7a29c" />
<img width="450" height="996" alt="image" src="https://github.com/user-attachments/assets/6219b085-adbe-484e-9bc2-d7d92660d2fd" />
<img width="464" height="999" alt="sucess_mapping_claims" src="https://github.com/user-attachments/assets/3b12e793-03ec-49e6-91cc-6ce6da72dd45" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
