### PR TITLE
fix save invalid disease code

### DIFF
--- a/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 
 public class ClaimActivity extends ImisActivity {
@@ -236,7 +237,7 @@ public class ClaimActivity extends ImisActivity {
         btnPost.setOnClickListener(v -> {
             progressDialog = ProgressDialog.show(this, "", getResources().getString(R.string.Processing));
             runOnNewThread(
-                    () -> isValidData() && saveClaim(),
+                    () -> isValidData() && isValidDiagnosis() && saveClaim(),
                     () -> runOnUiThread(() -> {
                         ClearForm();
                         progressDialog.dismiss();
@@ -790,6 +791,26 @@ public class ClaimActivity extends ImisActivity {
             return false;
         }
 
+        return true;
+    }
+
+    private boolean isValidDiagnosis(){
+        List<AutoCompleteTextView> diagnosisList = new ArrayList<>();
+        diagnosisList.add(etDiagnosis);
+        diagnosisList.add(etDiagnosis1);
+        diagnosisList.add(etDiagnosis2);
+        diagnosisList.add(etDiagnosis3);
+        diagnosisList.add(etDiagnosis4);
+
+        for(AutoCompleteTextView diagnosis : diagnosisList){
+            if(!diagnosis.getText().toString().isEmpty()){
+                String name = sqlHandler.getReferenceName(diagnosis.getText().toString());
+                if(name.equals(getResources().getString(R.string.Unknown))){
+                    showValidationDialog(diagnosis, getResources().getString(R.string.invalidDisease));
+                    return false;
+                }
+            }
+        }
         return true;
     }
 

--- a/claimManagement/src/main/res/values-fr/strings.xml
+++ b/claimManagement/src/main/res/values-fr/strings.xml
@@ -221,4 +221,5 @@
   <string name="NoItemsPricelist">La formation sanitaire n\'a pas de liste de prix pour les produits </string>
   <string name="entered">Entrée</string>
   <string name="News">Nouveautés:</string>
+  <string name="invalidDisease">Code de diagnostic invalide</string>
 </resources>

--- a/claimManagement/src/main/res/values/strings.xml
+++ b/claimManagement/src/main/res/values/strings.xml
@@ -256,4 +256,5 @@
     <string name="NoServicesPricelist">This healthfacility don\'t have services pricelist</string>
     <string name="NoItemsPricelist">This healthfacility don\'t have items pricelist</string>
     <string name="News">New changes:</string>
+    <string name="invalidDisease">Invalid disease code</string>
 </resources>


### PR DESCRIPTION
# Description

users are able to save claim with invalid disease code. we add disease code verification after form validation

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo


https://github.com/user-attachments/assets/2447e038-9c1c-477a-9a2b-c3a14d549a2f



## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
