### PR TITLE
fix unable cancel claim deletion

### DIFF
--- a/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
@@ -311,7 +311,7 @@ public class ClaimActivity extends ImisActivity {
             } else {
                 Log.e(LOG_TAG, "Delete claim invoked, but no claim UUID");
             }
-        });
+        }, (dialog, which) -> dialog.dismiss());
     }
 
     private void confirmArchive() {


### PR DESCRIPTION
# Description

When user click to delete a claim, he can no longer cancel the action because the dialog window does not close. to fix i added a cancel button in dialog

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Demo

<img width="360" height="800" alt="Screenshot_20260529_155154" src="https://github.com/user-attachments/assets/bd61554f-ceef-4d89-b42e-8579526b6b26" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
