### PR TITLE
Align startup language with system locale in claims app

### DIFF
--- a/claimManagement/src/main/java/org/openimis/imisclaims/ImisActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ImisActivity.java
@@ -21,6 +21,7 @@ import org.openimis.imisclaims.tools.Log;
 import org.openimis.imisclaims.usecase.Login;
 
 import java.util.ArrayList;
+import java.util.Locale;
 
 public abstract class ImisActivity extends AppCompatActivity {
 
@@ -48,7 +49,9 @@ public abstract class ImisActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         global = (Global) getApplicationContext();
-        global.setLanguage(this, global.getSavedLanguage());
+        String systemLanguage = resolveStartupLanguage();
+        global.setSavedLanguage(systemLanguage);
+        global.setLanguage(this, systemLanguage);
 
         actionBar = getSupportActionBar();
         if (actionBar != null) {
@@ -63,6 +66,15 @@ public abstract class ImisActivity extends AppCompatActivity {
         };
 
         sqlHandler = new SQLHandler(this);
+    }
+
+    private String resolveStartupLanguage() {
+        Locale systemLocale = getResources().getConfiguration().locale;
+        String language = systemLocale != null ? systemLocale.getLanguage() : "";
+        if ("fr".equalsIgnoreCase(language)) {
+            return "fr";
+        }
+        return "en";
     }
 
     @Override

--- a/claimManagement/src/test/java/org/openimis/imisclaims/ImisActivityTest.java
+++ b/claimManagement/src/test/java/org/openimis/imisclaims/ImisActivityTest.java
@@ -1,0 +1,39 @@
+package org.openimis.imisclaims;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+public class ImisActivityTest {
+
+    static class TestActivity extends ImisActivity {}
+
+    private String savedLanguage() {
+        TestActivity activity = Robolectric.buildActivity(TestActivity.class)
+                .create()
+                .get();
+
+        return activity.global.getSavedLanguage();
+    }
+
+    @Test
+    @Config(qualifiers = "fr")
+    public void french_locale_saves_fr() {
+        assertEquals("fr", savedLanguage());
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    public void english_locale_saves_en() {
+        assertEquals("en", savedLanguage());
+    }
+
+    @Test
+    @Config(qualifiers = "es")
+    public void unsupported_locale_defaults_en() {
+        assertEquals("en", savedLanguage());
+    }
+}


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

Align startup language with device locale in the mobile claims app. Defaults to system language, with fallback to English when the locale is neither French nor English, improving initial localization and user experience.

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify
- [x] Enhancement

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
