### PR TITLE
fix alphanumeric character in chfid

### DIFF
--- a/claimManagement/src/main/res/layout/activity_claim.xml
+++ b/claimManagement/src/main/res/layout/activity_claim.xml
@@ -105,7 +105,7 @@
                         android:layout_weight="1"
                         android:ems="10"
                         android:fontFamily="sans-serif-light"
-                        android:inputType="number"
+                        android:inputType="text"
                         android:maxLength="12"></EditText>
 
                 </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
# Description

Unable to enter alphabetical characters for insuree number in the mobile claim release but in the web it is possible to write numeric and alphabetic characters

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="720" height="1600" alt="Screenshot_20260610-174242" src="https://github.com/user-attachments/assets/be8c540f-2f18-46a5-987a-bc07b257f52b" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
