### PR TITLE
Retrieve and Apply Claim Form Configurations from the Web version

### DIFF
--- a/claimManagement/src/main/graphql/org.openimis.imisclaim/GetConfigs.graphql
+++ b/claimManagement/src/main/graphql/org.openimis.imisclaim/GetConfigs.graphql
@@ -1,0 +1,6 @@
+query GetConfigs {
+    moduleConfigurations {
+        config,
+        module
+    }
+}

--- a/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
@@ -9,6 +9,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -44,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 
 public class ClaimActivity extends ImisActivity {
@@ -82,7 +85,13 @@ public class ClaimActivity extends ImisActivity {
     RadioButton rbEmergency, rbReferral, rbOther;
     ImageButton btnScan;
     CheckBox etPreAuthorization;
-    TextInputLayout tfReferal;
+    TextInputLayout tfReferal, tiPatientCondition;
+    JSONObject claimConfig;
+    JSONObject insureeConfig;
+    int codeMaxLength = 8, chfIdMaxLength = 12, numberOfAdditionalDiagnosis = 4;
+    boolean showPatientCondition = false, showPreAuthorization = false, canSaveClaimWithoutServiceNorItem = true;
+    List<AutoCompleteTextView> secDiagnosis = new ArrayList<>();
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -124,6 +133,7 @@ public class ClaimActivity extends ImisActivity {
         etPatientCondition = findViewById(R.id.patientCondition);
         etVisitType = findViewById(R.id.etVisitType);
         tfReferal = findViewById(R.id.tfReferal);
+        tiPatientCondition = findViewById(R.id.tiPatientCondition);
 
         String[] visitTypes = getResources().getStringArray(R.array.visitType);
         ArrayAdapter<String> visitTypeAdapter = new ArrayAdapter<>(this, android.R.layout.simple_dropdown_item_1line, visitTypes);
@@ -192,18 +202,26 @@ public class ClaimActivity extends ImisActivity {
         etDiagnosis1.setAdapter(adapter);
         etDiagnosis1.setThreshold(1);
         etDiagnosis1.setOnItemClickListener(adapter);
+        etDiagnosis1.setVisibility(View.GONE);
+        secDiagnosis.add(etDiagnosis1);
 
         etDiagnosis2.setAdapter(adapter);
         etDiagnosis2.setThreshold(1);
         etDiagnosis2.setOnItemClickListener(adapter);
+        etDiagnosis2.setVisibility(View.GONE);
+        secDiagnosis.add(etDiagnosis2);
 
         etDiagnosis3.setAdapter(adapter);
         etDiagnosis3.setThreshold(1);
         etDiagnosis3.setOnItemClickListener(adapter);
+        etDiagnosis3.setVisibility(View.GONE);
+        secDiagnosis.add(etDiagnosis3);
 
         etDiagnosis4.setAdapter(adapter);
         etDiagnosis4.setThreshold(1);
         etDiagnosis4.setOnItemClickListener(adapter);
+        etDiagnosis4.setVisibility(View.GONE);
+        secDiagnosis.add(etDiagnosis4);
 
         HFAdapter hfAdapter = new HFAdapter(ClaimActivity.this, sqlHandler);
         etReferalHF.setAdapter(hfAdapter);
@@ -222,6 +240,8 @@ public class ClaimActivity extends ImisActivity {
             showDialog(EndDate_Dialog_ID);
             return false;
         });
+
+        initConfigurations();
 
         findViewById(R.id.ivAddItem).setOnClickListener(v -> addItem());
         findViewById(R.id.ivAddService).setOnClickListener(v -> addService());
@@ -291,6 +311,88 @@ public class ClaimActivity extends ImisActivity {
                     ClearForm();
                 }
             });
+        }
+
+        etInsureeNumber.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                int length = s != null ? s.length() : 0;if (length > chfIdMaxLength) {
+                    etInsureeNumber.setError(getResources().getString(R.string.maxCharactersRequired, chfIdMaxLength));
+                } else {
+                    etInsureeNumber.setError(null);
+                }
+            }
+        });
+
+        etClaimCode.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                int length = s != null ? s.length() : 0;
+                if (length > codeMaxLength) {
+                    etClaimCode.setError(getResources().getString(R.string.maxCharactersRequired, codeMaxLength));
+                } else {
+                    etClaimCode.setError(null);
+                }
+            }
+        });
+    }
+
+    private void initConfigurations(){
+        try {
+            claimConfig = sqlHandler.getModuleConfig("fe-claim");
+            insureeConfig = sqlHandler.getModuleConfig("fe-insuree");
+
+            if(claimConfig.has("claimForm.codeMaxLength")){
+                codeMaxLength = claimConfig.getInt("claimForm.codeMaxLength");
+            }
+
+            if(insureeConfig.has("insureeForm.chfIdMaxLength")){
+                chfIdMaxLength = insureeConfig.getInt("insureeForm.chfIdMaxLength");
+            }
+
+            if(claimConfig.has("showPatientCondition")){
+                showPatientCondition = claimConfig.getBoolean("showPatientCondition");
+            }
+
+            if(claimConfig.has("showPreAuthorization")){
+                showPreAuthorization = claimConfig.getBoolean("showPreAuthorization");
+            }
+
+            if(claimConfig.has("claimForm.numberOfAdditionalDiagnosis")){
+                numberOfAdditionalDiagnosis = claimConfig.getInt("claimForm.numberOfAdditionalDiagnosis");
+            }
+
+            if(!showPreAuthorization){
+                etPreAuthorization.setVisibility(View.GONE);
+            } else {
+                etPreAuthorization.setVisibility(View.VISIBLE);
+            }
+
+            if(!showPatientCondition){
+                tiPatientCondition.setVisibility(View.GONE);
+            } else {
+                tiPatientCondition.setVisibility(View.VISIBLE);
+            }
+
+            for (int i = 0; i < numberOfAdditionalDiagnosis; i++){
+                secDiagnosis.get(i).setVisibility(View.VISIBLE);
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
         }
     }
 
@@ -729,8 +831,18 @@ public class ClaimActivity extends ImisActivity {
             return false;
         }
 
+        if(etClaimCode.getText().length() > codeMaxLength){
+            showValidationDialog(etClaimCode, getResources().getString(R.string.InvalidClaimCode, codeMaxLength));
+            return false;
+        }
+
         if (etInsureeNumber.getText().length() == 0) {
             showValidationDialog(etInsureeNumber, getResources().getString(R.string.MissingCHFID));
+            return false;
+        }
+
+        if(etInsureeNumber.getText().length() > chfIdMaxLength) {
+            showValidationDialog(etInsureeNumber, getResources().getString(R.string.invalidChfId, chfIdMaxLength));
             return false;
         }
 
@@ -785,7 +897,7 @@ public class ClaimActivity extends ImisActivity {
             return false;
         }
 
-        if (Float.parseFloat(tvItemTotal.getText().toString()) + Float.parseFloat(tvServiceTotal.getText().toString()) == 0) {
+        if (!canSaveClaimWithoutServiceNorItem && Float.parseFloat(tvItemTotal.getText().toString()) + Float.parseFloat(tvServiceTotal.getText().toString()) == 0) {
             showValidationDialog(tvItemTotal, getResources().getString(R.string.MissingClaim));
             return false;
         }
@@ -847,8 +959,10 @@ public class ClaimActivity extends ImisActivity {
         claimCV.put("ICDCode4", etDiagnosis4.getText().toString());
         claimCV.put("VisitType", etVisitType.getTag().toString());
         claimCV.put("ReferalHF", etReferalHF.getText().toString());
-        claimCV.put("PatientCondition", etPatientCondition.getTag().toString());
-        if(etPreAuthorization.isChecked()){
+        if(showPatientCondition){
+            claimCV.put("PatientCondition", etPatientCondition.getTag().toString());
+        }
+        if(showPreAuthorization && etPreAuthorization.isChecked()){
             claimCV.put("PreAuthorization", 1);
         }else{
             claimCV.put("PreAuthorization", 0);

--- a/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/MainActivity.java
@@ -43,12 +43,14 @@ import org.openimis.imisclaims.domain.entity.DiagnosesServicesMedications;
 import org.openimis.imisclaims.domain.entity.Diagnosis;
 import org.openimis.imisclaims.domain.entity.HealthFacility;
 import org.openimis.imisclaims.domain.entity.Medication;
+import org.openimis.imisclaims.domain.entity.ModuleConfig;
 import org.openimis.imisclaims.domain.entity.PaymentList;
 import org.openimis.imisclaims.domain.entity.Service;
 import org.openimis.imisclaims.domain.entity.SubServiceItem;
 import org.openimis.imisclaims.tools.Log;
 import org.openimis.imisclaims.usecase.CheckHealthFacility;
 import org.openimis.imisclaims.usecase.FetchClaimAdmins;
+import org.openimis.imisclaims.usecase.FetchConfigs;
 import org.openimis.imisclaims.usecase.FetchControls;
 import org.openimis.imisclaims.usecase.FetchDiagnosesServicesItems;
 import org.openimis.imisclaims.usecase.FetchHealthfacilities;
@@ -741,6 +743,7 @@ public class MainActivity extends ImisActivity {
                         runOnUiThread(() -> {
                             progressDialog.dismiss();
                             Toast.makeText(MainActivity.this, getResources().getString(R.string.MapSuccessful), Toast.LENGTH_LONG).show();
+                            downloadConfigs();
                         });
                     } catch (Exception e) {
                         e.printStackTrace();
@@ -758,6 +761,45 @@ public class MainActivity extends ImisActivity {
             ErrorDialogBox(getResources().getString(R.string.CheckInternet));
         }
 
+    }
+
+    public void downloadConfigs (){
+        if (global.isNetworkAvailable()){
+            String progress_message = getResources().getString(R.string.getConfig) + "...";
+            progressDialog = ProgressDialog.show(this, getResources().getString(R.string.download), progress_message);
+            Thread thread = new Thread() {
+                public void run() {
+                    try {
+                        List<ModuleConfig> configs = new FetchConfigs().execute();
+                        if(!configs.isEmpty()){
+                            sqlHandler.ClearAll("tblConfig");
+                            for (int i = 0; i < configs.size(); i++) {
+                                sqlHandler.InsertConfig(i+1,configs.get(i).getModule(), configs.get(i).getConfig());
+                            }
+                        }
+                        runOnUiThread(() -> {
+                            progressDialog.dismiss();
+                            Toast.makeText(MainActivity.this, getResources().getString(R.string.downloaded_config), Toast.LENGTH_LONG).show();
+                        });
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        Sentry.captureException(e);
+                        runOnUiThread(() -> {
+                            progressDialog.dismiss();
+                            if(!global.isNetworkAvailable()){
+                                Toast.makeText(MainActivity.this,  getResources().getString(R.string.CheckInternet), Toast.LENGTH_LONG).show();
+                            }else {
+                                Toast.makeText(MainActivity.this, e.getMessage() + "-" + getResources().getString(R.string.AccessDenied), Toast.LENGTH_LONG).show();
+                            }
+                        });
+                    }
+                };
+            };
+            thread.start();
+        } else {
+            runOnUiThread(() -> progressDialog.dismiss());
+            ErrorDialogBox(getResources().getString(R.string.CheckInternet));
+        }
     }
 
     public void saveLastUpdateDate(String lastUpdateDate) {

--- a/claimManagement/src/main/java/org/openimis/imisclaims/SQLHandler.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/SQLHandler.java
@@ -49,6 +49,7 @@ public class SQLHandler extends SQLiteOpenHelper {
     private static final String CreateTableSubServices = "CREATE TABLE IF NOT EXISTS tblSubServices(ServiceId text, ServiceLinked text, Quantity text, Price text);";
     private static final String CreateTableSubItems = "CREATE TABLE IF NOT EXISTS tblSubItems(ItemId text, ServiceId text, Quantity text, Price text);";
     private static final String CreateTableHealthFacilities = "CREATE TABLE IF NOT EXISTS tblHealthFacilities(Id TEXT, Code TEXT, Name TEXT);";
+    private static final String createTableModuleConfig = "CREATE TABLE IF NOT EXISTS tblConfig(Id INTEGER, Module TEXT, Config TEXT);";
 
     public final String REFERENCE_UNKNOWN;
 
@@ -331,7 +332,7 @@ public class SQLHandler extends SQLiteOpenHelper {
         String[] commands = {CreateTableControls, CreateTableReferences, CreateTableClaimAdmins,
                 createTablePolicyInquiry, createTableClaimDetails, createTableClaimItems, createTableClaimServices,
                 createTableClaimUploadStatus, CreateTableSubItems,
-                CreateTableSubServices,CreateTableItems,CreateTableServices, CreateTableHealthFacilities};
+                CreateTableSubServices,CreateTableItems,CreateTableServices, CreateTableHealthFacilities, createTableModuleConfig};
         for (String command : commands) {
             try {
                 db.execSQL(command);
@@ -948,5 +949,35 @@ public class SQLHandler extends SQLiteOpenHelper {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    public void InsertConfig(int id, String module, String config) {
+        try {
+            ContentValues cv = new ContentValues();
+            cv.put("Id", id);
+            cv.put("Module", module);
+            cv.put("Config", config);
+
+            db.insert("tblConfig", null, cv);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public JSONObject getModuleConfig(String module){
+        JSONObject config = new JSONObject();
+        try {
+            String query = "SELECT Config FROM tblConfig WHERE Module = \"" + module + "\"";
+            Cursor cursor1 = db.rawQuery(query, null);
+            // looping through all rows
+            if (cursor1.moveToFirst()) {
+                do {
+                    config = new JSONObject(cursor1.getString(0));
+                } while (cursor1.moveToNext());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return config;
     }
 }

--- a/claimManagement/src/main/java/org/openimis/imisclaims/domain/entity/ModuleConfig.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/domain/entity/ModuleConfig.java
@@ -1,0 +1,29 @@
+package org.openimis.imisclaims.domain.entity;
+
+import androidx.annotation.NonNull;
+
+public class ModuleConfig {
+
+    @NonNull
+    private final String config;
+    @NonNull
+    private final String module;
+
+    public ModuleConfig(
+            @NonNull String config,
+            @NonNull String module
+    ) {
+        this.config = config;
+        this.module = module;
+    }
+
+    @NonNull
+    public String getConfig() {
+        return config;
+    }
+
+    @NonNull
+    public String getModule() {
+        return module;
+    }
+}

--- a/claimManagement/src/main/java/org/openimis/imisclaims/network/request/GetConfigGraphQLRequest.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/network/request/GetConfigGraphQLRequest.java
@@ -1,0 +1,17 @@
+package org.openimis.imisclaims.network.request;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.WorkerThread;
+
+import org.openimis.imisclaims.GetConfigsQuery;
+
+import java.util.List;
+
+public class GetConfigGraphQLRequest extends BaseGraphQLRequest {
+
+    @NonNull
+    @WorkerThread
+    public List<GetConfigsQuery.ModuleConfiguration> get() throws Exception {
+        return makeSynchronous(new GetConfigsQuery()).getData().moduleConfigurations();
+    }
+}

--- a/claimManagement/src/main/java/org/openimis/imisclaims/network/util/OkHttpUtils.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/network/util/OkHttpUtils.java
@@ -9,6 +9,8 @@ import org.openimis.imisclaims.Global;
 import org.openimis.imisclaims.network.okhttp.AuthorizationInterceptor;
 import org.openimis.imisclaims.network.util.PersistentCookieJar;
 
+import java.time.Duration;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
@@ -31,6 +33,7 @@ public class OkHttpUtils {
             synchronized (OkHttpUtils.class) {
                 if (client == null) {
                     OkHttpClient.Builder builder = new OkHttpClient.Builder();
+                    builder.readTimeout(Duration.ofSeconds(30));
                     PersistentCookieJar cookieJar =
                             new PersistentCookieJar(Global.getGlobal().getDefaultSharedPreferences());
                     Global.getGlobal().setCookieJar(cookieJar);

--- a/claimManagement/src/main/java/org/openimis/imisclaims/usecase/FetchConfigs.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/usecase/FetchConfigs.java
@@ -1,0 +1,37 @@
+package org.openimis.imisclaims.usecase;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.WorkerThread;
+
+import org.openimis.imisclaims.domain.entity.ModuleConfig;
+import org.openimis.imisclaims.network.request.GetConfigGraphQLRequest;
+import org.openimis.imisclaims.network.util.Mapper;
+
+import java.util.List;
+
+public class FetchConfigs {
+
+    @NonNull
+    private final GetConfigGraphQLRequest request;
+
+    public FetchConfigs() {
+        this(new GetConfigGraphQLRequest());
+    }
+
+    public FetchConfigs(
+            @NonNull GetConfigGraphQLRequest request
+    ) {
+        this.request = request;
+    }
+
+    @WorkerThread
+    @NonNull
+    public List<ModuleConfig> execute() throws Exception {
+        return Mapper.map(request.get(), dto -> {
+            return new ModuleConfig(
+                    /* config = */ dto.config(),
+                    /* module = */ dto.module()
+            );
+        });
+    }
+}

--- a/claimManagement/src/main/res/layout/activity_claim.xml
+++ b/claimManagement/src/main/res/layout/activity_claim.xml
@@ -66,8 +66,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="50dp"
                     android:ems="10"
-                    android:fontFamily="sans-serif-light"
-                    android:maxLength="8">
+                    android:fontFamily="sans-serif-light">
                     <requestFocus />
                 </EditText>
             </com.google.android.material.textfield.TextInputLayout>
@@ -105,8 +104,7 @@
                         android:layout_weight="1"
                         android:ems="10"
                         android:fontFamily="sans-serif-light"
-                        android:inputType="number"
-                        android:maxLength="12"></EditText>
+                        android:inputType="number"></EditText>
 
                 </com.google.android.material.textfield.TextInputLayout>
 
@@ -306,6 +304,7 @@
                 android:text="@string/preAuthorization"/>
 
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tiPatientCondition"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"

--- a/claimManagement/src/main/res/values-fr/strings.xml
+++ b/claimManagement/src/main/res/values-fr/strings.xml
@@ -221,4 +221,9 @@
   <string name="NoItemsPricelist">La formation sanitaire n\'a pas de liste de prix pour les produits </string>
   <string name="entered">Entrée</string>
   <string name="News">Nouveautés:</string>
+  <string name="getConfig">Modules configurations</string>
+  <string name="downloaded_config">Configurations downloaded successfully</string>
+  <string name="InvalidClaimCode">Le code de la prestation doit contenir maximum %d caractères</string>
+  <string name="maxCharactersRequired">Maximum %d caractères</string>
+  <string name="invalidChfId">Le numéro d\'assuré doit contenir maximum %d caractères</string>
 </resources>

--- a/claimManagement/src/main/res/values/strings.xml
+++ b/claimManagement/src/main/res/values/strings.xml
@@ -256,4 +256,9 @@
     <string name="NoServicesPricelist">This healthfacility don\'t have services pricelist</string>
     <string name="NoItemsPricelist">This healthfacility don\'t have items pricelist</string>
     <string name="News">New changes:</string>
+    <string name="getConfig">Configurations des modules</string>
+    <string name="downloaded_config">Configurations téléchargées avec succès</string>
+    <string name="InvalidClaimCode">The claim code must be %d characters maximum</string>
+    <string name="maxCharactersRequired">Maximum %d characters</string>
+    <string name="invalidChfId">The insuree number must be %d characters maximum</string>
 </resources>

--- a/claimManagement/src/test/java/org/openimis/imisclaims/ClaimActivityTest.java
+++ b/claimManagement/src/test/java/org/openimis/imisclaims/ClaimActivityTest.java
@@ -183,14 +183,31 @@ public class ClaimActivityTest {
     }
 
     @Test
-    public void isValidData_NoItemsAndServices_ReturnsFalse() {
+    public void isValidData_NoItemsAndServices_ReturnsTrue() {
         ClaimActivity.lvItemList.clear();
         ClaimActivity.lvServiceList.clear();
         activity.tvItemTotal.setText("0");
         activity.tvServiceTotal.setText("0");
 
         boolean result = activity.isValidData();
+        if(activity.canSaveClaimWithoutServiceNorItem){
+            assertTrue(result);
+        } else {
+            assertFalse(result);
+        }
+    }
 
+    @Test
+    public void isValidData_ChfIdMaxLength_ReturnsFalse(){
+        activity.etInsureeNumber.setText("12345678901234567890");
+        boolean result = activity.isValidData();
+        assertFalse(result);
+    }
+
+    @Test
+    public void isValidData_ClaimCodeMaxLength_ReturnsFalse(){
+        activity.etClaimCode.setText("CGDHHYY2903");
+        boolean result = activity.isValidData();
         assertFalse(result);
     }
 


### PR DESCRIPTION
# Description

In accordance with the web claim form, the visibility of certain fields is driven by configuration settings. The font size used for the CHFID and claim code fields also depends on configuration parameters. Likewise, the ability to save a service with or without services/items is configuration-driven.
The purpose of this enhancement is therefore to retrieve these configuration settings and apply them to the mobile claim form. If no configuration is available, the default values and behaviors should be applied, consistent with the web application

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="720" height="1600" alt="Screenshot_20260701_120605" src="https://github.com/user-attachments/assets/505a078a-9224-4a3a-a2ab-9caa1ac631e3" />
<img width="720" height="1600" alt="Screenshot_20260701_115037" src="https://github.com/user-attachments/assets/920933ca-cff7-4711-9e27-d7f43d3fe3c9" />
<img width="720" height="1600" alt="Screenshot_20260701_102334" src="https://github.com/user-attachments/assets/71c0016d-2de9-4e7f-82d8-b3ecda36d047" />
<img width="720" height="1600" alt="Screenshot_20260701_102311" src="https://github.com/user-attachments/assets/35b3dc99-5fe3-45e3-b302-41a2394bfe30" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
