### PR TITLE
Set the Default Visit Date to Today in the Mobile Claim Form

### DIFF
--- a/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
@@ -403,7 +403,6 @@ public class ClaimActivity extends ImisActivity {
                 dialog = new DatePickerDialog(this, EndDatePickerListner, year, month, day);
 
                 String startDateStr = etStartDate.getText().toString();
-                Log.e("date de début", startDateStr);
                 if (!startDateStr.isEmpty()) {
                     try {
                         Date startDate = DateUtils.dateFromString(startDateStr);

--- a/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
@@ -47,6 +47,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.UUID;
 
+import io.sentry.Sentry;
+
 public class ClaimActivity extends ImisActivity {
     private static final String LOG_TAG = "CLAIM";
     private static final int REQUEST_SCAN_QR_CODE = 1;
@@ -408,6 +410,7 @@ public class ClaimActivity extends ImisActivity {
                         Date startDate = DateUtils.dateFromString(startDateStr);
                         dialog.getDatePicker().setMinDate(startDate.getTime());
                     } catch (Exception e) {
+                        Sentry.captureException(e);
                         e.printStackTrace();
                     }
                 }

--- a/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
+++ b/claimManagement/src/main/java/org/openimis/imisclaims/ClaimActivity.java
@@ -40,6 +40,7 @@ import org.openimis.imisclaims.tools.Log;
 import org.openimis.imisclaims.util.DateUtils;
 import org.openimis.imisclaims.util.TextViewUtils;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -213,6 +214,8 @@ public class ClaimActivity extends ImisActivity {
         etPreAuthorization.setChecked(false);
         tfReferal.setVisibility(View.GONE);
 
+        LocalDate today = LocalDate.now();
+        etStartDate.setText(today.toString());
         etStartDate.setOnTouchListener((v, event) -> {
             showDialog(StartDate_Dialog_ID);
             return false;
@@ -384,22 +387,33 @@ public class ClaimActivity extends ImisActivity {
 
     @Override
     protected Dialog onCreateDialog(int id) {
+        DatePickerDialog dialog;
+        year = cal.get(Calendar.YEAR);
+        month = cal.get(Calendar.MONTH);
+        day = cal.get(Calendar.DAY_OF_MONTH);
+
         switch (id) {
 
             case StartDate_Dialog_ID:
-
-                year = cal.get(Calendar.YEAR);
-                month = cal.get(Calendar.MONTH);
-                day = cal.get(Calendar.DAY_OF_MONTH);
-
-                return new DatePickerDialog(this, StartdatePickerListener, year, month, day);
+                dialog = new DatePickerDialog(this, StartdatePickerListener, year, month, day);
+                dialog.getDatePicker().setMaxDate(System.currentTimeMillis());
+                return dialog;
 
             case EndDate_Dialog_ID:
-                year = cal.get(Calendar.YEAR);
-                month = cal.get(Calendar.MONTH);
-                day = cal.get(Calendar.DAY_OF_MONTH);
+                dialog = new DatePickerDialog(this, EndDatePickerListner, year, month, day);
 
-                return new DatePickerDialog(this, EndDatePickerListner, year, month, day);
+                String startDateStr = etStartDate.getText().toString();
+                Log.e("date de début", startDateStr);
+                if (!startDateStr.isEmpty()) {
+                    try {
+                        Date startDate = DateUtils.dateFromString(startDateStr);
+                        dialog.getDatePicker().setMinDate(startDate.getTime());
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+                dialog.getDatePicker().setMaxDate(System.currentTimeMillis());
+                return dialog;
         }
         return null;
     }


### PR DESCRIPTION
# Description

On the web application, the Visit Date From field is automatically initialized with the current date when creating a claim.
On the mobile application, this field is left empty by default.
To ensure consistency with the web application, the Visit Date From field should also default to the current date on mobile

I also disabled dates later than the current date in the startDate field to match the behavior of the web application.
Additionally, users were able to select an end date that was earlier than the visit start date or later than the current date, which is not allowed on the web application. I corrected this behavior to ensure consistency with the web implementation

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo


https://github.com/user-attachments/assets/9eab5dea-35c6-4229-8e51-ed19b407471a



## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
