### PR TITLE
Allow Alphanumeric Values in the Insured Number Field

### DIFF
--- a/claimManagement/src/main/res/layout/activity_claim.xml
+++ b/claimManagement/src/main/res/layout/activity_claim.xml
@@ -105,7 +105,7 @@
                         android:layout_weight="1"
                         android:ems="10"
                         android:fontFamily="sans-serif-light"
-                        android:inputType="number"
+                        android:inputType="text"
                         android:maxLength="12"></EditText>
 
                 </com.google.android.material.textfield.TextInputLayout>

--- a/claimManagement/src/main/res/layout/content_enquire.xml
+++ b/claimManagement/src/main/res/layout/content_enquire.xml
@@ -21,7 +21,7 @@
             android:id="@+id/etCHFID"
             android:layout_width="150dp"
             android:layout_height="50dp"
-            android:inputType="number"
+            android:inputType="text"
             android:hint="@string/CHFID"
             android:maxLength="12"
             android:layout_marginTop="10dp"


### PR DESCRIPTION
# Description

The Insured Number field currently accepts only numeric characters.
However, on the web application, insured numbers (CHFIDs) can contain alphanumeric characters. The mobile application should therefore allow alphanumeric input to ensure consistency with the web application and support all valid insured numbers

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1423" height="661" alt="Screenshot 2026-07-13 at 11 09 43 AM" src="https://github.com/user-attachments/assets/c48e2912-d7a5-48e8-9c3a-8a09ec413a41" />
<img width="720" height="1600" alt="Screenshot_20260713_111114" src="https://github.com/user-attachments/assets/102fdc88-32be-4479-aa3d-6555f8f09abe" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
